### PR TITLE
Virtual threads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - paper-plugin-port
+      - virtual-threads
   pull_request:
 
 jobs:

--- a/src/main/java/doublemoon/mahjongcraft/paper/AsyncService.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/AsyncService.java
@@ -1,0 +1,36 @@
+package doublemoon.mahjongcraft.paper;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class AsyncService implements AutoCloseable {
+    private final Logger logger;
+    private final ExecutorService executor;
+
+    public AsyncService(Logger logger) {
+        this.logger = logger;
+        this.executor = Executors.newVirtualThreadPerTaskExecutor();
+    }
+
+    public void execute(String taskName, Runnable task) {
+        try {
+            this.executor.execute(() -> {
+                try {
+                    task.run();
+                } catch (Throwable throwable) {
+                    this.logger.log(Level.WARNING, "Async task failed: " + taskName, throwable);
+                }
+            });
+        } catch (RejectedExecutionException ignored) {
+            this.logger.fine("Ignoring async task after executor shutdown: " + taskName);
+        }
+    }
+
+    @Override
+    public void close() {
+        this.executor.close();
+    }
+}

--- a/src/main/java/doublemoon/mahjongcraft/paper/MahjongPaperPlugin.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/MahjongPaperPlugin.java
@@ -61,7 +61,7 @@ public final class MahjongPaperPlugin extends JavaPlugin {
         this.getServer().getScheduler().runTask(this, () -> {
             this.craftEngine.initializeAfterStartup();
             if (this.tableManager != null) {
-                this.tableManager.tables().forEach(table -> table.render());
+                this.tableManager.refreshPersistentTablesAfterStartup();
             }
         });
         this.getLogger().info("MahjongPaper enabled.");

--- a/src/main/java/doublemoon/mahjongcraft/paper/MahjongPaperPlugin.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/MahjongPaperPlugin.java
@@ -16,6 +16,7 @@ public final class MahjongPaperPlugin extends JavaPlugin {
     private final MessageService messages = new MessageService();
     private PluginSettings settings;
     private DebugService debug;
+    private AsyncService async;
     private DatabaseService database;
     private CraftEngineService craftEngine;
     private MahjongTableManager tableManager;
@@ -25,6 +26,7 @@ public final class MahjongPaperPlugin extends JavaPlugin {
         this.saveDefaultConfig();
         this.settings = PluginSettings.from(this.getConfig());
         this.debug = new DebugService(this.getLogger(), this.settings.debugSection());
+        this.async = new AsyncService(this.getLogger());
         this.debug.log("lifecycle", "Debug logging enabled.");
         this.craftEngine = new CraftEngineService(this, this.settings.craftEngineSection());
 
@@ -81,6 +83,10 @@ public final class MahjongPaperPlugin extends JavaPlugin {
             this.database.close();
             this.database = null;
         }
+        if (this.async != null) {
+            this.async.close();
+            this.async = null;
+        }
         this.craftEngine = null;
         if (this.debug != null) {
             this.debug.log("lifecycle", "Plugin shutdown complete.");
@@ -112,6 +118,10 @@ public final class MahjongPaperPlugin extends JavaPlugin {
 
     public DebugService debug() {
         return this.debug;
+    }
+
+    public AsyncService async() {
+        return this.async;
     }
 
     public CraftEngineService craftEngine() {

--- a/src/main/java/doublemoon/mahjongcraft/paper/command/MahjongCommand.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/command/MahjongCommand.java
@@ -356,47 +356,51 @@ public final class MahjongCommand implements BasicCommand {
     @Override
     public List<String> suggest(CommandSourceStack stack, String[] args) {
         CommandSender sender = stack.getSender();
+        if (args.length == 0) {
+            return this.visibleRootCommands(sender);
+        }
+        String rootArg = args[0].toLowerCase(Locale.ROOT);
         if (args.length == 1) {
             return matchPrefix(args[0], this.visibleRootCommands(sender));
         }
         if (!(sender instanceof Player player)) {
             return List.of();
         }
-        if (this.isAdminRootCommand(args[0].toLowerCase(Locale.ROOT)) && !player.hasPermission("mahjongpaper.admin")) {
+        if (this.isAdminRootCommand(rootArg) && !player.hasPermission("mahjongpaper.admin")) {
             return List.of();
         }
 
-        if (args.length == 2 && ("forceend".equalsIgnoreCase(args[0]) || "deletetable".equalsIgnoreCase(args[0]))) {
+        if (args.length == 2 && ("forceend".equals(rootArg) || "deletetable".equals(rootArg))) {
             return matchPrefix(args[1], this.tableManager.tableIds());
         }
-        if (args.length == 2 && "botmatch".equalsIgnoreCase(args[0])) {
+        if (args.length == 2 && "botmatch".equals(rootArg)) {
             return matchPrefix(args[1], BOTMATCH_PRESETS);
         }
-        if (args.length == 2 && "mode".equalsIgnoreCase(args[0])) {
+        if (args.length == 2 && "mode".equals(rootArg)) {
             MahjongTableSession table = this.tableManager.tableFor(player.getUniqueId());
             return table == null ? List.of() : matchPrefix(args[1], table.ruleValues("mode"));
         }
-        if (args.length == 2 && ("join".equalsIgnoreCase(args[0]) || "spectate".equalsIgnoreCase(args[0]))) {
+        if (args.length == 2 && ("join".equals(rootArg) || "spectate".equals(rootArg))) {
             return matchPrefix(args[1], this.tableManager.tableIds());
         }
-        if (args.length == 2 && "kan".equalsIgnoreCase(args[0])) {
+        if (args.length == 2 && "kan".equals(rootArg)) {
             return matchPrefix(args[1], suggestedKanTiles(player));
         }
-        if (args.length == 2 && "rule".equalsIgnoreCase(args[0])) {
+        if (args.length == 2 && "rule".equals(rootArg)) {
             MahjongTableSession table = this.tableManager.tableFor(player.getUniqueId());
             return table == null ? List.of() : matchPrefix(args[1], table.ruleKeys());
         }
-        if (args.length == 3 && "rule".equalsIgnoreCase(args[0])) {
+        if (args.length == 3 && "rule".equals(rootArg)) {
             MahjongTableSession table = this.tableManager.tableFor(player.getUniqueId());
             return table == null ? List.of() : matchPrefix(args[2], table.ruleValues(args[1]));
         }
-        if (args.length == 2 && "chii".equalsIgnoreCase(args[0])) {
+        if (args.length == 2 && "chii".equals(rootArg)) {
             return matchPrefix(args[1], suggestedChiiFirstTiles(player));
         }
-        if (args.length == 3 && "chii".equalsIgnoreCase(args[0])) {
+        if (args.length == 3 && "chii".equals(rootArg)) {
             return matchPrefix(args[2], suggestedChiiSecondTiles(player, args[1]));
         }
-        if (args.length == 2 && "riichi".equalsIgnoreCase(args[0])) {
+        if (args.length == 2 && "riichi".equals(rootArg)) {
             return matchPrefix(args[1], suggestedRiichiIndices(player));
         }
         return List.of();

--- a/src/main/java/doublemoon/mahjongcraft/paper/compat/CraftEngineService.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/compat/CraftEngineService.java
@@ -87,7 +87,7 @@ public final class CraftEngineService {
         }
 
         if (this.exportBundleOnEnable) {
-            Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> this.exportBundle(craftEngine));
+            this.plugin.async().execute("export-craftengine-bundle", () -> this.exportBundle(craftEngine));
         }
     }
 

--- a/src/main/java/doublemoon/mahjongcraft/paper/db/DatabaseService.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/db/DatabaseService.java
@@ -63,7 +63,7 @@ public final class DatabaseService {
 
     public void persistRoundResultAsync(MahjongTableSession session, RoundResolution resolution) {
         this.plugin.debug().log("database", "Queueing round persistence for table=" + session.id() + " title=" + resolution.getTitle());
-        this.plugin.getServer().getScheduler().runTaskAsynchronously(this.plugin, () -> {
+        this.plugin.async().execute("persist-round-result", () -> {
             try {
                 this.persistRoundResult(session, resolution);
                 this.plugin.debug().log("database", "Persisted round result for table=" + session.id() + " title=" + resolution.getTitle());

--- a/src/main/java/doublemoon/mahjongcraft/paper/i18n/LocalizedMessages.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/i18n/LocalizedMessages.java
@@ -68,7 +68,7 @@ public final class LocalizedMessages {
     }
 
     public TagResolver number(Locale locale, String key, Number value) {
-        Locale formatLocale = this.resolveLocales(locale).get(0);
+        Locale formatLocale = this.resolveLocales(locale).getFirst();
         NumberFormat format = this.integerFormats.computeIfAbsent(
             formatLocale,
             resolvedLocale -> ThreadLocal.withInitial(() -> NumberFormat.getIntegerInstance(resolvedLocale))
@@ -81,7 +81,7 @@ public final class LocalizedMessages {
             return this.index.defaultLocale();
         }
         Locale locale = Locale.forLanguageTag(rawLocale.replace('_', '-'));
-        return locale.getLanguage().isBlank() ? this.index.defaultLocale() : this.resolveLocales(locale).get(0);
+        return locale.getLanguage().isBlank() ? this.index.defaultLocale() : this.resolveLocales(locale).getFirst();
     }
 
     private List<Locale> resolveLocales(Locale locale) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/DisplayEntities.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/DisplayEntities.java
@@ -58,6 +58,21 @@ public final class DisplayEntities {
         boolean visibleByDefault,
         Collection<UUID> privateViewers
     ) {
+        return spawnTileDisplay(plugin, location, yaw, tile, pose, clickAction, visibleByDefault, privateViewers, TILE_SCALE, null);
+    }
+
+    public static ItemDisplay spawnTileDisplay(
+        Plugin plugin,
+        Location location,
+        float yaw,
+        MahjongTile tile,
+        TileRenderPose pose,
+        DisplayClickAction clickAction,
+        boolean visibleByDefault,
+        Collection<UUID> privateViewers,
+        float scale,
+        Color glowColor
+    ) {
         World world = location.getWorld();
         if (world == null) {
             throw new IllegalArgumentException("Location world is null");
@@ -74,14 +89,19 @@ public final class DisplayEntities {
             spawned.setViewRange(32.0F);
             spawned.setShadowRadius(0.0F);
             spawned.setShadowStrength(0.0F);
-            spawned.setDisplayWidth(0.4F);
-            spawned.setDisplayHeight(0.6F);
+            spawned.setDisplayWidth(0.4F * scale);
+            spawned.setDisplayHeight(0.6F * scale);
             spawned.setRotation(yaw, 0.0F);
             spawned.setVisibleByDefault(!restrictedVisibility && visibleByDefault);
+            if (glowColor != null) {
+                spawned.setGlowing(true);
+                spawned.setGlowColorOverride(glowColor);
+                spawned.setBrightness(new Display.Brightness(15, 15));
+            }
             spawned.setTransformation(new Transformation(
                 new Vector3f(),
                 new AxisAngle4f((float) Math.toRadians(pose.xRotationDegrees()), 1.0F, 0.0F, 0.0F),
-                new Vector3f(TILE_SCALE, TILE_SCALE, TILE_SCALE),
+                new Vector3f(scale, scale, scale),
                 new AxisAngle4f()
             ));
             spawned.setItemStack(tileItem(plugin, tile, pose.faceDown()));

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderLayout.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderLayout.java
@@ -5,7 +5,6 @@ import doublemoon.mahjongcraft.paper.model.SeatWind;
 import doublemoon.mahjongcraft.paper.riichi.model.ScoringStick;
 import doublemoon.mahjongcraft.paper.table.MahjongTableSession;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 
@@ -391,9 +390,8 @@ public final class TableRenderLayout {
             ));
         }
 
-        SeatWind direction = placements.get(placements.size() - 1).face();
-        List<DeadWallPlacementMutable> reversed = new ArrayList<>(placements);
-        Collections.reverse(reversed);
+        SeatWind direction = placements.getLast().face();
+        List<DeadWallPlacementMutable> reversed = placements.reversed();
         for (int index = 0; index < reversed.size(); index++) {
             DeadWallPlacementMutable placement = reversed.get(index);
             if (placement.face() == direction) {
@@ -408,7 +406,7 @@ public final class TableRenderLayout {
                 }
             }
 
-            Point base = reversed.get(0).point();
+            Point base = reversed.getFirst().point();
             double positionY = reversed.get(index % 2 == 0 ? 0 : 1).point().y();
             double offset = WALL_TILE_STEP * (index / 2);
             placement.setPoint(switch (direction) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
@@ -435,6 +435,13 @@ public final class TableRenderer {
         return spawned;
     }
 
+    public List<Entity> renderWallTile(MahjongTableSession session, TableRenderLayout.LayoutPlan plan, int wallIndex) {
+        if (!session.isStarted() || wallIndex < 0 || wallIndex >= plan.wallTiles().size()) {
+            return List.of();
+        }
+        return List.of(spawnPublicTile(session, plan.wallTiles().get(wallIndex)));
+    }
+
     public List<Entity> renderSticks(
         MahjongTableSession session,
         MahjongTableSession.SeatRenderSnapshot seat,
@@ -672,6 +679,30 @@ public final class TableRenderer {
             ));
         }
         return spawned;
+    }
+
+    public List<Entity> renderHandPublicTile(
+        MahjongTableSession session,
+        MahjongTableSession.RenderSnapshot snapshot,
+        MahjongTableSession.SeatRenderSnapshot seat,
+        TableRenderLayout.SeatLayoutPlan plan,
+        int tileIndex
+    ) {
+        if (seat.playerId() == null || tileIndex < 0 || tileIndex >= seat.hand().size()) {
+            return List.of();
+        }
+
+        boolean concealHand = snapshot.started();
+        return List.of(DisplayEntities.spawnTileDisplay(
+            session.plugin(),
+            toLocation(session, plan.publicHandPoints().get(tileIndex)),
+            plan.yaw(),
+            concealHand ? MahjongTile.UNKNOWN : seat.hand().get(tileIndex),
+            DisplayEntities.TileRenderPose.STANDING,
+            null,
+            true,
+            seat.viewerIdsExcluding()
+        ));
     }
 
     public List<Entity> renderMelds(MahjongTableSession session, SeatWind wind) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
@@ -38,6 +38,8 @@ public final class TableRenderer {
     private static final double DISPLAY_CENTER_Y_OFFSET = 0.52D;
     private static final double TABLE_VISUAL_Y_OFFSET = 0.5D;
     private static final double FLOATING_TEXT_Y_OFFSET = 1.0D;
+    private static final double CENTER_LABEL_Y_OFFSET = 0.3D + FLOATING_TEXT_Y_OFFSET - 0.5D;
+    private static final double CENTER_LAST_DISCARD_TILE_Y_OFFSET = CENTER_LABEL_Y_OFFSET - 0.28D;
     private static final double WALL_DIRECTION_OFFSET = 1.0D;
     private static final double HAND_DIRECTION_OFFSET = WALL_DIRECTION_OFFSET + TILE_DEPTH + TILE_HEIGHT;
     private static final double HALF_TABLE_LENGTH_NO_BORDER = 0.5D + 15.0D / 16.0D;
@@ -486,12 +488,23 @@ public final class TableRenderer {
 
     public List<Entity> renderCenterLabel(MahjongTableSession session) {
         Location center = displayCenter(session);
-        return List.of(DisplayEntities.spawnLabel(
+        List<Entity> spawned = new ArrayList<>(2);
+        spawned.add(DisplayEntities.spawnLabel(
             session.plugin(),
-            center.clone().add(0.0D, 0.3D + FLOATING_TEXT_Y_OFFSET, 0.0D),
+            center.clone().add(0.0D, CENTER_LABEL_Y_OFFSET, 0.0D),
             Component.text(session.publicCenterText()),
             Color.fromARGB(112, 20, 80, 20)
         ));
+        if (session.lastPublicDiscardTile() != null) {
+            spawned.add(spawnPublicTile(
+                session,
+                center.clone().add(0.0D, CENTER_LAST_DISCARD_TILE_Y_OFFSET, 0.0D),
+                0.0F,
+                session.lastPublicDiscardTile(),
+                DisplayEntities.TileRenderPose.FLAT_FACE_UP
+            ));
+        }
+        return List.copyOf(spawned);
     }
 
     public List<Entity> renderCenterLabel(
@@ -499,12 +512,24 @@ public final class TableRenderer {
         MahjongTableSession.RenderSnapshot snapshot,
         TableRenderLayout.LayoutPlan plan
     ) {
-        return List.of(DisplayEntities.spawnLabel(
+        Location center = toLocation(session, plan.displayCenter());
+        List<Entity> spawned = new ArrayList<>(2);
+        spawned.add(DisplayEntities.spawnLabel(
             session.plugin(),
-            toLocation(session, plan.displayCenter()).add(0.0D, 0.3D + FLOATING_TEXT_Y_OFFSET, 0.0D),
+            center.clone().add(0.0D, CENTER_LABEL_Y_OFFSET, 0.0D),
             Component.text(snapshot.publicCenterText()),
             Color.fromARGB(112, 20, 80, 20)
         ));
+        if (snapshot.lastPublicDiscardTile() != null) {
+            spawned.add(spawnPublicTile(
+                session,
+                center.clone().add(0.0D, CENTER_LAST_DISCARD_TILE_Y_OFFSET, 0.0D),
+                0.0F,
+                snapshot.lastPublicDiscardTile(),
+                DisplayEntities.TileRenderPose.FLAT_FACE_UP
+            ));
+        }
+        return List.copyOf(spawned);
     }
 
     public List<Entity> renderViewerOverlay(MahjongTableSession session, Player viewer) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
@@ -39,7 +39,9 @@ public final class TableRenderer {
     private static final double TABLE_VISUAL_Y_OFFSET = 0.5D;
     private static final double FLOATING_TEXT_Y_OFFSET = 1.0D;
     private static final double CENTER_LABEL_Y_OFFSET = 0.3D + FLOATING_TEXT_Y_OFFSET - 0.5D;
-    private static final double CENTER_LAST_DISCARD_TILE_Y_OFFSET = CENTER_LABEL_Y_OFFSET - 0.28D;
+    private static final double CENTER_LAST_DISCARD_TILE_Y_OFFSET = CENTER_LABEL_Y_OFFSET - 0.18D;
+    private static final float CENTER_LAST_DISCARD_TILE_SCALE = 2.0F;
+    private static final Color CENTER_LAST_DISCARD_TILE_GLOW = Color.fromRGB(255, 220, 96);
     private static final double WALL_DIRECTION_OFFSET = 1.0D;
     private static final double HAND_DIRECTION_OFFSET = WALL_DIRECTION_OFFSET + TILE_DEPTH + TILE_HEIGHT;
     private static final double HALF_TABLE_LENGTH_NO_BORDER = 0.5D + 15.0D / 16.0D;
@@ -496,13 +498,7 @@ public final class TableRenderer {
             Color.fromARGB(112, 20, 80, 20)
         ));
         if (session.lastPublicDiscardTile() != null) {
-            spawned.add(spawnPublicTile(
-                session,
-                center.clone().add(0.0D, CENTER_LAST_DISCARD_TILE_Y_OFFSET, 0.0D),
-                0.0F,
-                session.lastPublicDiscardTile(),
-                DisplayEntities.TileRenderPose.FLAT_FACE_UP
-            ));
+            spawned.add(spawnCenterLastDiscardTile(session, center, session.lastPublicDiscardTile()));
         }
         return List.copyOf(spawned);
     }
@@ -521,13 +517,7 @@ public final class TableRenderer {
             Color.fromARGB(112, 20, 80, 20)
         ));
         if (snapshot.lastPublicDiscardTile() != null) {
-            spawned.add(spawnPublicTile(
-                session,
-                center.clone().add(0.0D, CENTER_LAST_DISCARD_TILE_Y_OFFSET, 0.0D),
-                0.0F,
-                snapshot.lastPublicDiscardTile(),
-                DisplayEntities.TileRenderPose.FLAT_FACE_UP
-            ));
+            spawned.add(spawnCenterLastDiscardTile(session, center, snapshot.lastPublicDiscardTile()));
         }
         return List.copyOf(spawned);
     }
@@ -885,6 +875,25 @@ public final class TableRenderer {
 
     private static Entity spawnPublicTile(MahjongTableSession session, TableRenderLayout.TilePlacement placement) {
         return spawnPublicTile(session, toLocation(session, placement.point()), placement.yaw(), placement.tile(), placement.pose());
+    }
+
+    private static Entity spawnCenterLastDiscardTile(
+        MahjongTableSession session,
+        Location center,
+        MahjongTile tile
+    ) {
+        return DisplayEntities.spawnTileDisplay(
+            session.plugin(),
+            center.clone().add(0.0D, CENTER_LAST_DISCARD_TILE_Y_OFFSET, 0.0D),
+            0.0F,
+            tile,
+            DisplayEntities.TileRenderPose.STANDING,
+            null,
+            true,
+            null,
+            CENTER_LAST_DISCARD_TILE_SCALE,
+            CENTER_LAST_DISCARD_TILE_GLOW
+        );
     }
 
     private static Location toLocation(MahjongTableSession session, TableRenderLayout.Point point) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java
@@ -5,7 +5,6 @@ import doublemoon.mahjongcraft.paper.model.SeatWind;
 import doublemoon.mahjongcraft.paper.table.MahjongTableSession;
 import doublemoon.mahjongcraft.paper.riichi.model.ScoringStick;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
@@ -903,9 +902,8 @@ public final class TableRenderer {
             ));
         }
 
-        SeatWind direction = placements.get(placements.size() - 1).face();
-        List<DeadWallPlacementMutable> reversed = new ArrayList<>(placements);
-        Collections.reverse(reversed);
+        SeatWind direction = placements.getLast().face();
+        List<DeadWallPlacementMutable> reversed = placements.reversed();
         for (int index = 0; index < reversed.size(); index++) {
             DeadWallPlacementMutable placement = reversed.get(index);
             if (placement.face() == direction) {
@@ -920,7 +918,7 @@ public final class TableRenderer {
                 }
             }
 
-            Location base = reversed.get(0).location();
+            Location base = reversed.getFirst().location();
             double positionY = reversed.get(index % 2 == 0 ? 0 : 1).location().getY();
             double offset = WALL_TILE_STEP * (index / 2);
             placement.setLocation(switch (direction) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java
@@ -48,6 +48,7 @@ public final class MahjongTableManager implements Listener {
     private final Map<UUID, String> playerTables = new LinkedHashMap<>();
     private final Map<UUID, String> spectatorTables = new LinkedHashMap<>();
     private final Map<TableChunkKey, Set<String>> tablesByChunk = new LinkedHashMap<>();
+    private final Set<String> pendingArtifactCleanupTableIds = new HashSet<>();
     private final Map<UUID, RecentHandTileClick> recentHandTileClicks = new HashMap<>();
     private final BukkitTask tableTickTask;
 
@@ -114,6 +115,7 @@ public final class MahjongTableManager implements Listener {
         if (!session.addPlayer(player)) {
             return null;
         }
+        this.cleanupLoadedTableArtifactsIfNeeded(session);
         this.playerTables.put(player.getUniqueId(), session.id());
         this.plugin.debug().log("table", player.getName() + " joined table " + session.id());
         session.render();
@@ -141,6 +143,7 @@ public final class MahjongTableManager implements Listener {
         if (!session.addPlayer(player, wind)) {
             return null;
         }
+        this.cleanupLoadedTableArtifactsIfNeeded(session);
         this.spectatorTables.remove(playerId);
         session.removeSpectator(playerId);
         this.playerTables.put(playerId, session.id());
@@ -161,6 +164,7 @@ public final class MahjongTableManager implements Listener {
         if (!session.addSpectator(player)) {
             return null;
         }
+        this.cleanupLoadedTableArtifactsIfNeeded(session);
         this.spectatorTables.put(player.getUniqueId(), session.id());
         this.plugin.debug().log("table", player.getName() + " is spectating table " + session.id());
         session.render();
@@ -263,6 +267,7 @@ public final class MahjongTableManager implements Listener {
             MahjongTableSession session = new MahjongTableSession(this.plugin, id, loadedTable.center(), loadedTable.rule(), true);
             this.tables.put(id, session);
             this.indexTable(session);
+            this.pendingArtifactCleanupTableIds.add(id);
             this.cleanupTableArtifacts(session.center());
             session.render();
             this.plugin.debug().log("table", "Loaded persistent table " + id);
@@ -307,6 +312,7 @@ public final class MahjongTableManager implements Listener {
         for (UUID spectatorId : session.spectators()) {
             this.spectatorTables.remove(spectatorId);
         }
+        this.pendingArtifactCleanupTableIds.remove(session.id());
         this.unindexTable(session);
         session.shutdown();
         this.cleanupTableArtifacts(center);
@@ -368,6 +374,7 @@ public final class MahjongTableManager implements Listener {
         this.playerTables.clear();
         this.spectatorTables.clear();
         this.tablesByChunk.clear();
+        this.pendingArtifactCleanupTableIds.clear();
     }
 
     @EventHandler
@@ -405,15 +412,12 @@ public final class MahjongTableManager implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onChunkLoad(ChunkLoadEvent event) {
-        Collection<String> tableIds = this.tablesByChunk.get(TableChunkKey.from(event.getChunk()));
-        if (tableIds == null || tableIds.isEmpty()) {
-            return;
-        }
-        for (String tableId : tableIds) {
-            MahjongTableSession session = this.tables.get(tableId);
-            if (session != null) {
-                session.render();
+        for (MahjongTableSession session : this.tables.values()) {
+            if (!this.affectsTableArea(event.getChunk(), session)) {
+                continue;
             }
+            this.cleanupLoadedTableArtifactsIfNeeded(session);
+            session.render();
         }
     }
 
@@ -478,6 +482,27 @@ public final class MahjongTableManager implements Listener {
         if (removed > 0) {
             this.plugin.debug().log("table", "Cleaned " + removed + " table entities near " + center.getBlockX() + "," + center.getBlockY() + "," + center.getBlockZ());
         }
+    }
+
+    private void cleanupLoadedTableArtifactsIfNeeded(MahjongTableSession session) {
+        if (session == null || !this.pendingArtifactCleanupTableIds.remove(session.id())) {
+            return;
+        }
+        Location center = session.center();
+        session.clearDisplays();
+        this.cleanupTableArtifacts(center);
+        this.plugin.debug().log("table", "Deferred startup cleanup finished for persistent table " + session.id());
+    }
+
+    private boolean affectsTableArea(Chunk chunk, MahjongTableSession session) {
+        Location center = session.center();
+        World world = center.getWorld();
+        if (world == null || !world.equals(chunk.getWorld())) {
+            return false;
+        }
+        int centerChunkX = center.getBlockX() >> 4;
+        int centerChunkZ = center.getBlockZ() >> 4;
+        return Math.abs(centerChunkX - chunk.getX()) <= 1 && Math.abs(centerChunkZ - chunk.getZ()) <= 1;
     }
 
     private record RecentHandTileClick(String tableId, UUID ownerId, int tileIndex, long timestampNanos) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java
@@ -284,7 +284,7 @@ public final class MahjongTableManager implements Listener {
             if (!session.isPersistentRoom()) {
                 continue;
             }
-            this.cleanupLoadedTableArtifactsIfNeeded(session);
+            this.refreshPersistentTableArtifacts(session);
             session.render();
         }
     }
@@ -498,10 +498,18 @@ public final class MahjongTableManager implements Listener {
         if (session == null || !this.pendingArtifactCleanupTableIds.remove(session.id())) {
             return;
         }
+        this.refreshPersistentTableArtifacts(session);
+        this.plugin.debug().log("table", "Deferred startup cleanup finished for persistent table " + session.id());
+    }
+
+    private void refreshPersistentTableArtifacts(MahjongTableSession session) {
+        if (session == null) {
+            return;
+        }
+        this.pendingArtifactCleanupTableIds.remove(session.id());
         Location center = session.center();
         session.clearDisplays();
         this.cleanupTableArtifacts(center);
-        this.plugin.debug().log("table", "Deferred startup cleanup finished for persistent table " + session.id());
     }
 
     private boolean affectsTableArea(Chunk chunk, MahjongTableSession session) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java
@@ -279,6 +279,16 @@ public final class MahjongTableManager implements Listener {
         this.persistentTableStore.save(this.tables.values());
     }
 
+    public void refreshPersistentTablesAfterStartup() {
+        for (MahjongTableSession session : this.tables.values()) {
+            if (!session.isPersistentRoom()) {
+                continue;
+            }
+            this.cleanupLoadedTableArtifactsIfNeeded(session);
+            session.render();
+        }
+    }
+
     public MahjongTableSession.ReadyResult start(Player player) {
         MahjongTableSession session = this.tableFor(player.getUniqueId());
         if (session == null) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
@@ -2300,6 +2300,8 @@ public final class MahjongTableSession {
             .field("center")
             .field(snapshot.started() ? "started" : "waiting")
             .field(snapshot.publicCenterText())
+            .field(snapshot.lastPublicDiscardPlayerId())
+            .field(snapshot.lastPublicDiscardTile())
             .toString();
     }
 
@@ -2866,7 +2868,7 @@ public final class MahjongTableSession {
                 this.plugin.messages().number(locale, "wall", this.remainingWall().size()),
                 this.plugin.messages().number(locale, "dice", this.dicePoints()),
                 this.plugin.messages().tag("dealer", this.dealerName(locale)),
-                this.plugin.messages().tag("last_discard", this.lastDiscardSummary(locale))
+                this.plugin.messages().tag("last_discard", this.centerLastDiscardSummary(locale))
             );
         }
         return this.plugin.messages().plain(
@@ -2876,6 +2878,10 @@ public final class MahjongTableSession {
             this.plugin.messages().tag("summary", this.waitingDisplaySummary(locale)),
             this.plugin.messages().tag("rules", this.ruleDisplaySummary(locale))
         );
+    }
+
+    public doublemoon.mahjongcraft.paper.model.MahjongTile lastPublicDiscardTile() {
+        return this.lastPublicDiscardTile;
     }
 
     private String roundWindText(Locale locale) {
@@ -2931,6 +2937,17 @@ public final class MahjongTableSession {
             "table.last_discard",
             this.plugin.messages().tag("player", this.displayName(this.lastPublicDiscardPlayerId, locale)),
             this.plugin.messages().tag("tile", this.tileLabel(locale, this.lastPublicDiscardTile.name()))
+        );
+    }
+
+    private String centerLastDiscardSummary(Locale locale) {
+        if (this.lastPublicDiscardPlayerId == null || this.lastPublicDiscardTile == null) {
+            return this.plugin.messages().plain(locale, "table.last_discard_none");
+        }
+        return this.plugin.messages().plain(
+            locale,
+            "table.last_discard_player",
+            this.plugin.messages().tag("player", this.displayName(this.lastPublicDiscardPlayerId, locale))
         );
     }
 

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
@@ -53,6 +53,7 @@ public final class MahjongTableSession {
     private static final String REGION_DORA = "dora";
     private static final String REGION_CENTER = "center";
     private static final long NEXT_ROUND_DELAY_MILLIS = 8000L;
+    private static final int MAX_WALL_TILE_REGIONS = 136;
     private static final int MAX_HAND_TILE_REGIONS = 14;
     private static final int MAX_DISCARD_TILE_REGIONS = 24;
 
@@ -513,7 +514,7 @@ public final class MahjongTableSession {
         Map<String, String> fingerprints = result.regionFingerprints();
 
         this.updateRegion(REGION_TABLE, fingerprints.get(REGION_TABLE), () -> this.renderer.renderTableStructure(this, plan));
-        this.updateRegion(REGION_WALL, fingerprints.get(REGION_WALL), () -> this.renderer.renderWall(this, plan));
+        this.updateWallRegions(plan);
         this.updateRegion(REGION_DORA, fingerprints.get(REGION_DORA), () -> this.renderer.renderDora(this, plan));
         this.updateRegion(REGION_CENTER, fingerprints.get(REGION_CENTER), () -> this.renderer.renderCenterLabel(this, snapshot, plan));
         for (SeatWind wind : SeatWind.values()) {
@@ -521,7 +522,7 @@ public final class MahjongTableSession {
             TableRenderLayout.SeatLayoutPlan seatPlan = plan.seat(wind);
             this.updateRegion(this.seatRegionKey("labels", wind), fingerprints.get(this.seatRegionKey("labels", wind)), () -> this.renderer.renderSeatLabels(this, seat, seatPlan));
             this.updateRegion(this.seatRegionKey("sticks", wind), fingerprints.get(this.seatRegionKey("sticks", wind)), () -> this.renderer.renderSticks(this, seat, seatPlan));
-            this.updateRegion(this.seatRegionKey("hand-public", wind), fingerprints.get(this.seatRegionKey("hand-public", wind)), () -> this.renderer.renderHandPublic(this, snapshot, seat, seatPlan));
+            this.updatePublicHandRegions(snapshot, seat, seatPlan);
             this.updatePrivateHandRegions(seat, seatPlan);
             this.updateDiscardRegions(seat, seatPlan);
             this.updateRegion(this.seatRegionKey("melds", wind), fingerprints.get(this.seatRegionKey("melds", wind)), () -> this.renderer.renderMelds(this, seat, seatPlan));
@@ -2396,6 +2397,43 @@ public final class MahjongTableSession {
             .toString();
     }
 
+    private void updatePublicHandRegions(RenderSnapshot snapshot, SeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
+        this.clearRegion(this.seatRegionKey("hand-public", seat.wind()));
+        int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
+            String regionKey = this.handPublicRegionKey(seat.wind(), tileIndex);
+            if (tileIndex >= handSize) {
+                this.clearRegion(regionKey);
+                continue;
+            }
+            int index = tileIndex;
+            this.updateRegion(
+                regionKey,
+                this.handPublicTileFingerprint(snapshot, seat, plan, tileIndex),
+                () -> this.renderer.renderHandPublicTile(this, snapshot, seat, plan, index)
+            );
+        }
+    }
+
+    private String handPublicTileFingerprint(RenderSnapshot snapshot, SeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, int tileIndex) {
+        TableRenderLayout.Point point = plan.publicHandPoints().get(tileIndex);
+        boolean concealHand = snapshot.started();
+        return fingerprintBuilder(160)
+            .field("hand-public-tile")
+            .field(seat.wind().name())
+            .field(Objects.toString(seat.playerId(), "empty"))
+            .field(tileIndex)
+            .field(snapshot.started())
+            .field(seat.online())
+            .field(seat.viewerMembershipSignature())
+            .field(seat.stickLayoutCount())
+            .field(Double.doubleToLongBits(point.x()))
+            .field(Double.doubleToLongBits(point.y()))
+            .field(Double.doubleToLongBits(point.z()))
+            .field(concealHand ? "unknown" : seat.hand().get(tileIndex).name())
+            .toString();
+    }
+
     private void updateDiscardRegions(SeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
         this.clearRegion(this.seatRegionKey("discards", seat.wind()));
         int discardCount = seat.playerId() == null ? 0 : plan.discardPlacements().size();
@@ -2422,6 +2460,38 @@ public final class MahjongTableSession {
             .field(Objects.toString(seat.playerId(), "empty"))
             .field(discardIndex)
             .field(seat.riichiDiscardIndex())
+            .field(Float.floatToIntBits(placement.yaw()))
+            .field(Double.doubleToLongBits(placement.point().x()))
+            .field(Double.doubleToLongBits(placement.point().y()))
+            .field(Double.doubleToLongBits(placement.point().z()))
+            .field(placement.tile().name())
+            .field(placement.pose().name())
+            .toString();
+    }
+
+    private void updateWallRegions(TableRenderLayout.LayoutPlan plan) {
+        this.clearRegion(REGION_WALL);
+        int wallTileCount = plan.wallTiles().size();
+        for (int wallIndex = 0; wallIndex < MAX_WALL_TILE_REGIONS; wallIndex++) {
+            String regionKey = this.wallRegionKey(wallIndex);
+            if (wallIndex >= wallTileCount) {
+                this.clearRegion(regionKey);
+                continue;
+            }
+            int index = wallIndex;
+            this.updateRegion(
+                regionKey,
+                this.wallTileFingerprint(plan, wallIndex),
+                () -> this.renderer.renderWallTile(this, plan, index)
+            );
+        }
+    }
+
+    private String wallTileFingerprint(TableRenderLayout.LayoutPlan plan, int wallIndex) {
+        TableRenderLayout.TilePlacement placement = plan.wallTiles().get(wallIndex);
+        return fingerprintBuilder(160)
+            .field("wall-tile")
+            .field(wallIndex)
             .field(Float.floatToIntBits(placement.yaw()))
             .field(Double.doubleToLongBits(placement.point().x()))
             .field(Double.doubleToLongBits(placement.point().y()))
@@ -2508,8 +2578,16 @@ public final class MahjongTableSession {
         return this.seatRegionKey("hand-private-" + tileIndex, wind);
     }
 
+    private String handPublicRegionKey(SeatWind wind, int tileIndex) {
+        return this.seatRegionKey("hand-public-" + tileIndex, wind);
+    }
+
     private String discardRegionKey(SeatWind wind, int discardIndex) {
         return this.seatRegionKey("discards-" + discardIndex, wind);
+    }
+
+    private String wallRegionKey(int wallIndex) {
+        return REGION_WALL + "-" + wallIndex;
     }
 
     private String meldFingerprint(SeatWind wind) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
@@ -1256,6 +1256,7 @@ public final class MahjongTableSession {
             return this.discard(playerId, tileIndex);
         }
         this.selectedHandTileIndices.put(playerId, tileIndex);
+        this.refreshSelectedHandTileView(playerId);
         this.render();
         return true;
     }
@@ -1284,6 +1285,24 @@ public final class MahjongTableSession {
             return false;
         }
         return this.engine.getCurrentPlayer().getUuid().equals(playerId.toString());
+    }
+
+    private void refreshSelectedHandTileView(UUID playerId) {
+        SeatWind wind = this.seatOf(playerId);
+        if (wind == null) {
+            return;
+        }
+        RenderSnapshot snapshot = this.captureRenderSnapshot(this.renderRequestVersion);
+        SeatRenderSnapshot seat = snapshot.seat(wind);
+        if (seat == null || seat.playerId() == null) {
+            return;
+        }
+        TableRenderLayout.LayoutPlan plan = TableRenderLayout.precompute(snapshot);
+        TableRenderLayout.SeatLayoutPlan seatPlan = plan.seat(wind);
+        if (seatPlan == null) {
+            return;
+        }
+        this.updatePrivateHandRegions(seat, seatPlan);
     }
 
     private doublemoon.mahjongcraft.paper.model.MahjongTile handTileAt(UUID playerId, int tileIndex) {

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java
@@ -472,7 +472,7 @@ public final class MahjongTableSession {
 
     private void startAsyncRenderPrecompute(RenderSnapshot snapshot) {
         this.renderPrecomputeRunning = true;
-        Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
+        this.plugin.async().execute("render-precompute-" + this.id, () -> {
             RenderPrecomputeResult result = new RenderPrecomputeResult(
                 snapshot,
                 this.precomputeRegionFingerprints(snapshot),

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/PersistentTableStore.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/PersistentTableStore.java
@@ -92,7 +92,7 @@ final class PersistentTableStore {
         if (!this.asyncSaveScheduled.compareAndSet(false, true)) {
             return;
         }
-        Bukkit.getScheduler().runTaskAsynchronously(this.plugin, this::drainPendingSaves);
+        this.plugin.async().execute("save-persistent-tables", this::drainPendingSaves);
     }
 
     private void drainPendingSaves() {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -148,6 +148,7 @@ table.public.seat_empty=[<seat>] Empty seat
 table.public.seat_status=[<seat>] <points> pts<status>
 table.public.center_active=<round><newline>Wall <wall> | Dice <dice> | Dealer <dealer><newline><last_discard>
 table.last_discard=<player> discarded <tile>
+table.last_discard_player=<player> discarded
 table.last_discard_none=No discard yet
 table.public.center_waiting=Mahjong Table <table_id><newline><summary><newline><rules>
 rule.length.one_game=One game

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -132,6 +132,7 @@ table.public.seat_empty=[<seat>] 空座
 table.public.seat_status=[<seat>] <points> 点<status>
 table.public.center_active=<round><newline>牌山 <wall> | 骰子 <dice> | 庄家 <dealer><newline><last_discard>
 table.last_discard=<player> 打出了 <tile>
+table.last_discard_player=<player> 打出了
 table.last_discard_none=还没有人打牌
 table.public.center_waiting=雀桌 <table_id><newline><summary><newline><rules>
 rule.length.one_game=一局

--- a/src/main/resources/messages_zh_HK.properties
+++ b/src/main/resources/messages_zh_HK.properties
@@ -132,6 +132,7 @@ table.public.seat_empty=[<seat>] 空位
 table.public.seat_status=[<seat>] <points> 點<status>
 table.public.center_active=<round><newline>牌山 <wall> | 骰仔 <dice> | 莊家 <dealer><newline><last_discard>
 table.last_discard=<player> 打出咗 <tile>
+table.last_discard_player=<player> 打出咗
 table.last_discard_none=仲未有人打牌
 table.public.center_waiting=麻雀枱 <table_id><newline><summary><newline><rules>
 rule.length.one_game=一局

--- a/src/main/resources/messages_zh_MO.properties
+++ b/src/main/resources/messages_zh_MO.properties
@@ -132,6 +132,7 @@ table.public.seat_empty=[<seat>] 空位
 table.public.seat_status=[<seat>] <points> 點<status>
 table.public.center_active=<round><newline>牌山 <wall> | 骰仔 <dice> | 莊家 <dealer><newline><last_discard>
 table.last_discard=<player> 打出咗 <tile>
+table.last_discard_player=<player> 打出咗
 table.last_discard_none=仲未有人打牌
 table.public.center_waiting=麻雀枱 <table_id><newline><summary><newline><rules>
 rule.length.one_game=一局

--- a/src/main/resources/messages_zh_TW.properties
+++ b/src/main/resources/messages_zh_TW.properties
@@ -132,6 +132,7 @@ table.public.seat_empty=[<seat>] 空位
 table.public.seat_status=[<seat>] <points> 點<status>
 table.public.center_active=<round><newline>牌山 <wall> | 骰子 <dice> | 莊家 <dealer><newline><last_discard>
 table.last_discard=<player> 打出了 <tile>
+table.last_discard_player=<player> 打出了
 table.last_discard_none=還沒有人打牌
 table.public.center_waiting=麻將桌 <table_id><newline><summary><newline><rules>
 rule.length.one_game=一局


### PR DESCRIPTION
## Summary

This PR moves safe async work onto Java 21 virtual threads and tightens persistent-table recovery after restart.

It also includes several table UX/render fixes that were developed on top of the branch:
- reduce hand/discard/full-table flicker
- refresh selected hand tiles immediately
- fix `/mahjong` empty suggestion crashes
- restore persistent table interactions after both clean and unclean restarts
- improve center-table discard display with highlighted tile rendering

## Main changes

### Java 21 / virtual threads
- add `AsyncService` backed by virtual threads
- move safe async work to the new service:
  - database round persistence
  - persistent table YAML saves
  - CraftEngine bundle export
  - render precompute work
- update CI to build the `virtual-threads` branch

### Persistent table restart recovery
- rebuild persistent tables after startup
- force cleanup of lingering table artifacts before re-rendering
- cover both clean shutdown restart and crash restart paths
- refresh seat/label interactions after restore

### Interaction and command fixes
- fix `/mahjong` command suggestion crash when Brigadier passes empty args
- keep hand selection responsive by refreshing selected tile visuals immediately

### Render polish
- reduce full-table flicker when other players discard
- show the latest discard tile in the center display
- make the center discard tile standing, enlarged, and highlighted
- keep localized center text aligned with the new tile display

## Files of note
- `.github/workflows/build.yml`
- `src/main/java/doublemoon/mahjongcraft/paper/AsyncService.java`
- `src/main/java/doublemoon/mahjongcraft/paper/MahjongPaperPlugin.java`
- `src/main/java/doublemoon/mahjongcraft/paper/command/MahjongCommand.java`
- `src/main/java/doublemoon/mahjongcraft/paper/render/DisplayEntities.java`
- `src/main/java/doublemoon/mahjongcraft/paper/render/TableRenderer.java`
- `src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableManager.java`
- `src/main/java/doublemoon/mahjongcraft/paper/table/MahjongTableSession.java`

## Validation
- `.\gradlew.bat build --console plain`
- `.\gradlew.bat compileJava --console plain`
- `.\gradlew.bat test --tests doublemoon.mahjongcraft.paper.render.TableRendererTest --tests doublemoon.mahjongcraft.paper.riichi.RiichiRoundEngineTest --tests doublemoon.mahjongcraft.paper.i18n.MessageServiceTest --console plain`

## Notes
- This branch currently targets Java 21-style runtime improvements and assumes a Java version that supports virtual threads.
- Restart recovery is now intentionally aggressive for persistent tables: startup refresh clears lingering artifacts before re-rendering.
