### PR TITLE
Fix Folia viewer visibility scheduler for display entities

### DIFF
--- a/src/main/java/doublemoon/mahjongcraft/paper/compat/CraftEngineService.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/compat/CraftEngineService.java
@@ -600,7 +600,7 @@ public final class CraftEngineService {
         if (entity == null || viewer == null || !this.plugin.isEnabled()) {
             return;
         }
-        this.plugin.scheduler().runEntity(viewer, () -> {
+        this.plugin.scheduler().runEntity(entity, () -> {
             if (!viewer.isOnline()) {
                 return;
             }

--- a/src/main/java/doublemoon/mahjongcraft/paper/render/display/DisplayEntities.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/render/display/DisplayEntities.java
@@ -1002,7 +1002,7 @@ public final class DisplayEntities {
 
     private static void runForViewer(Plugin plugin, Entity entity, org.bukkit.entity.Player player, Runnable runnable) {
         if (plugin instanceof doublemoon.mahjongcraft.paper.bootstrap.MahjongPaperPlugin mahjongPlugin) {
-            mahjongPlugin.scheduler().runEntity(player, () -> {
+            mahjongPlugin.scheduler().runEntity(entity, () -> {
                 if (!player.isOnline()) {
                     return;
                 }


### PR DESCRIPTION
## Summary
- fix viewer visibility resync to run on the tracked entity scheduler in CraftEngine integration
- apply the same scheduler correction to display visibility sync helpers
- avoid Folia/Luminol off-region entity access when calling showEntity/hideEntity

## Verification
- ./gradlew.bat compileJava