### PR TITLE
fix: auto-leave finished players and guard riichi edge cases

### DIFF
--- a/src/main/java/doublemoon/mahjongcraft/paper/command/MahjongCommand.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/command/MahjongCommand.java
@@ -193,6 +193,7 @@ public final class MahjongCommand implements BasicCommand {
                 MahjongTableManager.LeaveResult result = this.tableManager.leave(player.getUniqueId());
                 switch (result.status()) {
                     case LEFT -> this.messages.send(player, "command.left_table");
+                    case DEFERRED -> this.messages.send(player, "command.leave_deferred");
                     case UNSPECTATED -> this.messages.send(player, "command.unspectated");
                     case NOT_IN_TABLE -> this.messages.send(player, "command.not_in_table");
                     case BLOCKED -> this.messages.send(player, "command.leave_blocked_started");

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/core/MahjongTableManager.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/core/MahjongTableManager.java
@@ -188,7 +188,9 @@ public final class MahjongTableManager implements Listener {
                 : new LeaveResult(LeaveStatus.UNSPECTATED, spectatorSession);
         }
         if (session.isStarted()) {
-            return new LeaveResult(LeaveStatus.BLOCKED, session);
+            return session.queueLeaveAfterRound(playerId)
+                ? new LeaveResult(LeaveStatus.DEFERRED, session)
+                : new LeaveResult(LeaveStatus.BLOCKED, session);
         }
         SeatWind seatWind = session.seatOf(playerId);
         this.seatCoordinator.ejectSeatOccupant(playerId);
@@ -446,10 +448,11 @@ public final class MahjongTableManager implements Listener {
         }
         MahjongTableSession session = this.resolveTable(action.tableId());
         if (session != null && session.isStarted()) {
+            LeaveResult result = this.leave(player.getUniqueId());
             event.setCancelled(true);
             this.seatCoordinator.startSeatWatchdog(session, player.getUniqueId(), action.seatWind());
             this.seatCoordinator.requestSeatRestore(player, session, action.seatWind());
-            this.plugin.messages().actionBar(player, "command.leave_blocked_started");
+            this.plugin.messages().actionBar(player, result.status() == LeaveStatus.DEFERRED ? "command.leave_deferred" : "command.leave_blocked_started");
             return;
         }
         this.plugin.scheduler().runEntity(player, () -> this.leave(player.getUniqueId()));
@@ -468,9 +471,10 @@ public final class MahjongTableManager implements Listener {
         if (this.seatCoordinator.seatAction(player.getVehicle()) == null) {
             return;
         }
+        LeaveResult result = this.leave(player.getUniqueId());
         event.setCancelled(true);
         this.seatCoordinator.startSeatWatchdog(session, player.getUniqueId(), session.seatOf(player.getUniqueId()));
-        this.plugin.messages().actionBar(player, "command.leave_blocked_started");
+        this.plugin.messages().actionBar(player, result.status() == LeaveStatus.DEFERRED ? "command.leave_deferred" : "command.leave_blocked_started");
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -707,13 +711,16 @@ public final class MahjongTableManager implements Listener {
         this.directory.registerTable(session);
     }
 
-    public void finalizeDeferredLeaves(MahjongTableSession session, Collection<UUID> playerIds) {
-        if (session == null || playerIds == null || playerIds.isEmpty()) {
+    public void finalizeDeferredLeaves(MahjongTableSession session, Map<UUID, SeatWind> playerSeats) {
+        if (session == null || playerSeats == null || playerSeats.isEmpty()) {
             return;
         }
-        for (UUID playerId : playerIds) {
+        for (Map.Entry<UUID, SeatWind> entry : playerSeats.entrySet()) {
+            UUID playerId = entry.getKey();
+            SeatWind wind = entry.getValue();
             this.seatCoordinator.ejectSeatOccupant(playerId);
             this.directory.removePlayer(playerId);
+            this.seatCoordinator.movePlayerToSeatExit(playerId, session, wind);
             this.plugin.debug().log("table", "Player " + playerId + " left table " + session.id() + " after round end");
         }
         this.handleSeatMembershipChanged(session, true);
@@ -784,6 +791,7 @@ public final class MahjongTableManager implements Listener {
 
     public enum LeaveStatus {
         LEFT,
+        DEFERRED,
         UNSPECTATED,
         NOT_IN_TABLE,
         BLOCKED

--- a/src/main/java/doublemoon/mahjongcraft/paper/table/core/MahjongTableSession.java
+++ b/src/main/java/doublemoon/mahjongcraft/paper/table/core/MahjongTableSession.java
@@ -35,6 +35,7 @@ import doublemoon.mahjongcraft.paper.ui.SettlementUi;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1593,16 +1594,17 @@ public final class MahjongTableSession {
         if (!this.participants.hasQueuedLeaves() || this.isStarted()) {
             return;
         }
-        List<UUID> removed = new ArrayList<>();
+        Map<UUID, SeatWind> removed = new LinkedHashMap<>();
         for (UUID playerId : this.participants.queuedLeavePlayers()) {
+            SeatWind wind = this.seatOf(playerId);
             if (this.removePlayer(playerId)) {
-                removed.add(playerId);
+                removed.put(playerId, wind);
             }
         }
         if (removed.isEmpty()) {
             return;
         }
-        this.participants.removeQueuedLeaves(removed);
+        this.participants.removeQueuedLeaves(new ArrayList<>(removed.keySet()));
         if (this.plugin.tableManager() != null) {
             this.plugin.tableManager().finalizeDeferredLeaves(this, removed);
         }

--- a/src/main/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiPlayerState.kt
+++ b/src/main/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiPlayerState.kt
@@ -645,34 +645,36 @@ open class RiichiPlayerState(
         analysisStateVersion++
     }
 
-    private fun currentShantenResult(): UnionShantenResult {
+    private fun currentShantenResult(): UnionShantenResult? {
         if (cachedCurrentShantenVersion != analysisStateVersion || cachedCurrentShantenResult == null) {
             cachedCurrentShantenResult = analyzeShanten()
             cachedCurrentShantenVersion = analysisStateVersion
         }
-        return cachedCurrentShantenResult!!
+        return cachedCurrentShantenResult
     }
 
     private fun currentShantenWithGot(): ShantenWithGot? =
-        currentShantenResult().shantenInfo as? ShantenWithGot
+        currentShantenResult()?.shantenInfo as? ShantenWithGot
 
     private fun currentShantenWithoutGot(): ShantenWithoutGot? =
-        currentShantenResult().shantenInfo as? ShantenWithoutGot
+        currentShantenResult()?.shantenInfo as? ShantenWithoutGot
 
     private fun analyzeShanten(
         hands: List<MahjongTile> = this.hands.toMahjongTileList(),
         fuuroList: List<Fuuro> = this.fuuroList,
         bestShantenOnly: Boolean = true
-    ): UnionShantenResult = shanten(
-        tiles = hands.toUtilsTiles(),
-        furo = fuuroList.map { it.utilsFuro },
-        bestShantenOnly = bestShantenOnly
-    )
+    ): UnionShantenResult? = runCatching {
+        shanten(
+            tiles = hands.toUtilsTiles(),
+            furo = fuuroList.map { it.utilsFuro },
+            bestShantenOnly = bestShantenOnly
+        )
+    }.getOrNull()
 
     private fun shantenWithoutGot(
         hands: List<MahjongTile>,
         fuuroList: List<Fuuro>
-    ): ShantenWithoutGot? = analyzeShanten(hands, fuuroList).shantenInfo as? ShantenWithoutGot
+    ): ShantenWithoutGot? = analyzeShanten(hands, fuuroList)?.shantenInfo as? ShantenWithoutGot
 
     private fun discardTileInstance(tile: TileInstance) {
         hands -= tile

--- a/src/main/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiRoundEngine.kt
+++ b/src/main/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiRoundEngine.kt
@@ -237,6 +237,7 @@ class RiichiRoundEngine(
         val player = currentPlayer
         val ankanTile = player.tilesCanAnkan.find { it.mahjongTile == tile }
         if (ankanTile != null) {
+            if (!canDrawRinshanTile()) return false
             player.ankan(ankanTile)
             currentDrawIsRinshan = false
             pendingReaction = computeChankanReaction(player, ankanTile, allowOnlyKokushi = true)
@@ -250,6 +251,7 @@ class RiichiRoundEngine(
         }
         val kakanTile = player.hands.find { it.mahjongTile == tile && player.canKakan }
         if (kakanTile != null) {
+            if (!canDrawRinshanTile()) return false
             player.kakan(kakanTile)
             currentDrawIsRinshan = false
             pendingReaction = computeChankanReaction(player, kakanTile, allowOnlyKokushi = false)
@@ -380,6 +382,9 @@ class RiichiRoundEngine(
         currentDrawIsRinshan = true
         pendingAbortiveDraw = if (isSuukaikanAbort()) ExhaustiveDraw.SUUKAIKAN else null
     }
+
+    private fun canDrawRinshanTile(): Boolean =
+        deadWall.size >= 2 && wall.isNotEmpty()
 
     private fun computePendingReaction(discarder: RiichiPlayerState, tile: TileInstance): PendingReaction? {
         val options = linkedMapOf<String, ReactionOptions>()

--- a/src/test/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiPlayerStateTest.kt
+++ b/src/test/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiPlayerStateTest.kt
@@ -18,6 +18,28 @@ import kotlin.test.assertTrue
 
 class RiichiPlayerStateTest {
     @Test
+    fun `invalid hand size does not throw during shanten checks`() {
+        val player = RiichiPlayerState("Alice", "alice")
+        player.hands += tiles(
+            MahjongTile.M1,
+            MahjongTile.M2,
+            MahjongTile.M3,
+            MahjongTile.M4,
+            MahjongTile.M5,
+            MahjongTile.M6,
+            MahjongTile.P1,
+            MahjongTile.P2,
+            MahjongTile.P3,
+            MahjongTile.S1,
+            MahjongTile.S2,
+            MahjongTile.S3
+        )
+
+        assertFalse(player.isTenpai)
+        assertTrue(player.discardSuggestions().isEmpty())
+    }
+
+    @Test
     fun `tile pairs for riichi cache invalidates when hand changes`() {
         val player = RiichiPlayerState("Alice", "alice")
         player.drawTile(TileInstance(mahjongTile = MahjongTile.M1))

--- a/src/test/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiRoundEngineTest.kt
+++ b/src/test/kotlin/doublemoon/mahjongcraft/paper/riichi/RiichiRoundEngineTest.kt
@@ -331,6 +331,43 @@ class RiichiRoundEngineTest {
     }
 
     @Test
+    fun `ankan is rejected when no rinshan draw is available`() {
+        val engine = RiichiRoundEngine(
+            listOf(
+                RiichiPlayerState("East", "east"),
+                RiichiPlayerState("South", "south"),
+                RiichiPlayerState("West", "west"),
+                RiichiPlayerState("North", "north")
+            ),
+            MahjongRule()
+        )
+        engine.startRound()
+        val east = engine.currentPlayer
+        east.resetRoundState()
+        east.hands += tiles(
+            MahjongTile.EAST,
+            MahjongTile.EAST,
+            MahjongTile.EAST,
+            MahjongTile.EAST,
+            MahjongTile.M1,
+            MahjongTile.M2,
+            MahjongTile.M3,
+            MahjongTile.P1,
+            MahjongTile.P2,
+            MahjongTile.P3,
+            MahjongTile.S1,
+            MahjongTile.S2,
+            MahjongTile.S3,
+            MahjongTile.WHITE_DRAGON
+        )
+        engine.wall.clear()
+
+        assertFalse(engine.tryAnkanOrKakan(east.uuid, MahjongTile.EAST))
+        assertEquals(4, east.hands.count { it.mahjongTile == MahjongTile.EAST })
+        assertTrue(engine.pendingReaction == null)
+    }
+
+    @Test
     fun `pao ron splits yakuman payment between discarder and liable player`() {
         val engine = RiichiRoundEngine(
             listOf(


### PR DESCRIPTION
## Summary
- auto-queue `/mahjong leave` during active games and finalize seat cleanup after the hand ends
- ensure deferred leaves remove seat membership and move players off the seat cleanly
- guard riichi edge cases to avoid rinshan draw crashes and shanten calculation exceptions on invalid hand sizes

## Testing
- `./gradlew test --tests doublemoon.mahjongcraft.paper.riichi.RiichiRoundEngineTest --tests doublemoon.mahjongcraft.paper.riichi.RiichiPlayerStateTest --tests doublemoon.mahjongcraft.paper.table.core.MahjongTableSessionTest --tests doublemoon.mahjongcraft.paper.table.core.MahjongTableManagerTest`
- `./gradlew build`