### PR TITLE
Fix counterclockwise riichi turn order

### DIFF
--- a/src/main/kotlin/top/ellan/mahjong/riichi/RiichiPlayerState.kt
+++ b/src/main/kotlin/top/ellan/mahjong/riichi/RiichiPlayerState.kt
@@ -136,6 +136,7 @@ open class RiichiPlayerState(
     fun chii(
         tile: TileInstance,
         tilePair: Pair<MahjongTile, MahjongTile>,
+        claimTarget: ClaimTarget,
         target: RiichiPlayerState
     ) {
         lastDrawnTile = null
@@ -147,7 +148,7 @@ open class RiichiPlayerState(
         val fuuro = Fuuro(
             type = MeldType.CHII,
             tileInstances = tileShuntsu,
-            claimTarget = ClaimTarget.LEFT,
+            claimTarget = claimTarget,
             claimTile = tile
         )
         hands -= tileShuntsu.filter { it != tile }.toSet()

--- a/src/main/kotlin/top/ellan/mahjong/riichi/RiichiRoundEngine.kt
+++ b/src/main/kotlin/top/ellan/mahjong/riichi/RiichiRoundEngine.kt
@@ -392,7 +392,7 @@ class RiichiRoundEngine(
 
     private fun computePendingReaction(discarder: RiichiPlayerState, tile: TileInstance): PendingReaction? {
         val options = linkedMapOf<String, ReactionOptions>()
-        seatOrderFrom(discarder).drop(1).forEach { candidate ->
+        turnOrderFrom(discarder).drop(1).forEach { candidate ->
             val target = claimTarget(candidate, discarder)
             val canRon = candidate.canWin(
                 tile.mahjongTile,
@@ -401,7 +401,7 @@ class RiichiRoundEngine(
                 generalSituation = generalSituation,
                 personalSituation = personalSituation(candidate, isTsumo = false)
             ) && !candidate.isFuriten(tile, discards)
-            val reactionOptions = candidate.reactionOptionsFor(tile, allowChii = target == ClaimTarget.LEFT, canRon = canRon)
+            val reactionOptions = candidate.reactionOptionsFor(tile, allowChii = target == ClaimTarget.RIGHT, canRon = canRon)
             if (reactionOptions != null) {
                 options[candidate.uuid] = reactionOptions
             }
@@ -411,7 +411,7 @@ class RiichiRoundEngine(
 
     private fun computeChankanReaction(discarder: RiichiPlayerState, tile: TileInstance, allowOnlyKokushi: Boolean): PendingReaction? {
         val options = linkedMapOf<String, ReactionOptions>()
-        seatOrderFrom(discarder).drop(1).forEach { candidate ->
+        turnOrderFrom(discarder).drop(1).forEach { candidate ->
             val canRon = candidate.canWin(
                 tile.mahjongTile,
                 false,
@@ -471,7 +471,7 @@ class RiichiRoundEngine(
 
         val ponKanResponses = pending.responses.filterValues { it.type == ReactionType.PON || it.type == ReactionType.MINKAN }
         if (ponKanResponses.isNotEmpty()) {
-            val ordered = seatOrderFrom(seatPlayer(pending.discarderUuid)!!).drop(1)
+            val ordered = turnOrderFrom(seatPlayer(pending.discarderUuid)!!).drop(1)
             val winner = ordered.first { it.uuid in ponKanResponses.keys }
             val response = ponKanResponses[winner.uuid]!!
             val discarder = seatPlayer(pending.discarderUuid)!!
@@ -497,7 +497,7 @@ class RiichiRoundEngine(
         if (chiiResponse != null) {
             val winner = seatPlayer(chiiResponse.key)!!
             val discarder = seatPlayer(pending.discarderUuid)!!
-            winner.chii(pending.tile, chiiResponse.value.chiiPair!!, discarder)
+            winner.chii(pending.tile, chiiResponse.value.chiiPair!!, claimTarget(winner, discarder), discarder)
             currentPlayerIndex = seats.indexOf(winner)
             currentDrawIsRinshan = false
             pendingAbortiveDraw = null
@@ -524,7 +524,7 @@ class RiichiRoundEngine(
             resolveDraw(ExhaustiveDraw.NORMAL)
             return
         }
-        currentPlayerIndex = (currentPlayerIndex + 1) % seats.size
+        currentPlayerIndex = previousSeatIndex(currentPlayerIndex)
         currentPlayer.drawTile(wall.removeFirst())
         currentPlayer.hands.sortBy { it.mahjongTile.sortOrder }
     }
@@ -559,8 +559,8 @@ class RiichiRoundEngine(
         pendingAbortiveDraw = null
         val yakuSettlements = mutableListOf<YakuSettlement>()
         val scoreList = mutableListOf<ScoreItem>()
-        val seatOrderFromTarget = seatOrderFrom(target)
-        val atamahanePlayer = seatOrderFromTarget.firstOrNull { it in winners }
+        val turnOrderFromTarget = turnOrderFrom(target)
+        val atamahanePlayer = turnOrderFromTarget.firstOrNull { it in winners }
         val allRiichiStickQuantity = seats.sumOf { it.riichiStickAmount }
         val honbaScore = round.honba * 300
         val riichiPoolScore = allRiichiStickQuantity * ScoringStick.P1000.point
@@ -791,9 +791,9 @@ class RiichiRoundEngine(
     private fun seatOrderFromDealer(): List<RiichiPlayerState> =
         List(4) { seats[(round.round + it) % 4] }
 
-    private fun seatOrderFrom(target: RiichiPlayerState): List<RiichiPlayerState> {
+    private fun turnOrderFrom(target: RiichiPlayerState): List<RiichiPlayerState> {
         val index = seats.indexOf(target)
-        return List(4) { seats[(index + it) % 4] }
+        return List(4) { offset -> seats[Math.floorMod(index - offset, seats.size)] }
     }
 
     private fun claimTarget(claimer: RiichiPlayerState, discarder: RiichiPlayerState): ClaimTarget {
@@ -805,6 +805,9 @@ class RiichiRoundEngine(
             else -> ClaimTarget.SELF
         }
     }
+
+    private fun previousSeatIndex(index: Int): Int =
+        Math.floorMod(index - 1, seats.size)
 
     private fun isSuukaikanAbort(): Boolean {
         if (kanCount < 4) {

--- a/src/test/kotlin/top/ellan/mahjong/riichi/RiichiRoundEngineTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/riichi/RiichiRoundEngineTest.kt
@@ -174,6 +174,183 @@ class RiichiRoundEngineTest {
     }
 
     @Test
+    fun `turn advances counterclockwise after a discard`() {
+        val engine = RiichiRoundEngine(
+            listOf(
+                RiichiPlayerState("East", "east"),
+                RiichiPlayerState("South", "south"),
+                RiichiPlayerState("West", "west"),
+                RiichiPlayerState("North", "north")
+            ),
+            MahjongRule()
+        )
+        engine.startRound()
+        val east = engine.seats[0]
+        val south = engine.seats[1]
+        val west = engine.seats[2]
+        val north = engine.seats[3]
+        east.resetRoundState()
+        south.resetRoundState()
+        west.resetRoundState()
+        north.resetRoundState()
+        east.hands += tiles(
+            MahjongTile.M9,
+            MahjongTile.P1,
+            MahjongTile.P2,
+            MahjongTile.P3,
+            MahjongTile.S1,
+            MahjongTile.S2,
+            MahjongTile.S3,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH,
+            MahjongTile.WHITE_DRAGON,
+            MahjongTile.GREEN_DRAGON,
+            MahjongTile.RED_DRAGON
+        )
+        south.hands += tiles(
+            MahjongTile.M1,
+            MahjongTile.M4,
+            MahjongTile.M7,
+            MahjongTile.P1,
+            MahjongTile.P4,
+            MahjongTile.P7,
+            MahjongTile.S1,
+            MahjongTile.S4,
+            MahjongTile.S7,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH
+        )
+        west.hands += tiles(
+            MahjongTile.M2,
+            MahjongTile.M5,
+            MahjongTile.M8,
+            MahjongTile.P2,
+            MahjongTile.P5,
+            MahjongTile.P8,
+            MahjongTile.S2,
+            MahjongTile.S5,
+            MahjongTile.S8,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.WHITE_DRAGON
+        )
+        north.hands += tiles(
+            MahjongTile.M3,
+            MahjongTile.M6,
+            MahjongTile.P3,
+            MahjongTile.P6,
+            MahjongTile.P9,
+            MahjongTile.S3,
+            MahjongTile.S6,
+            MahjongTile.S9,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH,
+            MahjongTile.GREEN_DRAGON
+        )
+        engine.wall.clear()
+        engine.wall += TileInstance(mahjongTile = MahjongTile.M1)
+
+        assertTrue(engine.discard(east.uuid, 0))
+        assertEquals("north", engine.currentPlayer.uuid)
+        assertEquals(14, north.hands.size)
+    }
+
+    @Test
+    fun `only the counterclockwise next player can chii a discard`() {
+        val engine = RiichiRoundEngine(
+            listOf(
+                RiichiPlayerState("East", "east"),
+                RiichiPlayerState("South", "south"),
+                RiichiPlayerState("West", "west"),
+                RiichiPlayerState("North", "north")
+            ),
+            MahjongRule()
+        )
+        engine.startRound()
+        val east = engine.seats[0]
+        val south = engine.seats[1]
+        val west = engine.seats[2]
+        val north = engine.seats[3]
+        east.resetRoundState()
+        south.resetRoundState()
+        west.resetRoundState()
+        north.resetRoundState()
+        east.hands += tiles(
+            MahjongTile.M2,
+            MahjongTile.P1,
+            MahjongTile.P2,
+            MahjongTile.P3,
+            MahjongTile.S1,
+            MahjongTile.S2,
+            MahjongTile.S3,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH,
+            MahjongTile.WHITE_DRAGON,
+            MahjongTile.GREEN_DRAGON,
+            MahjongTile.RED_DRAGON
+        )
+        south.hands += tiles(
+            MahjongTile.M1,
+            MahjongTile.M3,
+            MahjongTile.P4,
+            MahjongTile.P5,
+            MahjongTile.P6,
+            MahjongTile.S4,
+            MahjongTile.S5,
+            MahjongTile.S6,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH,
+            MahjongTile.WHITE_DRAGON
+        )
+        west.hands += tiles(
+            MahjongTile.M4,
+            MahjongTile.M5,
+            MahjongTile.M6,
+            MahjongTile.P1,
+            MahjongTile.P4,
+            MahjongTile.P7,
+            MahjongTile.S1,
+            MahjongTile.S4,
+            MahjongTile.S7,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH
+        )
+        north.hands += tiles(
+            MahjongTile.M1,
+            MahjongTile.M3,
+            MahjongTile.P7,
+            MahjongTile.P8,
+            MahjongTile.P9,
+            MahjongTile.S7,
+            MahjongTile.S8,
+            MahjongTile.S9,
+            MahjongTile.EAST,
+            MahjongTile.SOUTH,
+            MahjongTile.WEST,
+            MahjongTile.NORTH,
+            MahjongTile.GREEN_DRAGON
+        )
+
+        assertTrue(engine.discard(east.uuid, 0))
+        assertEquals(listOf(MahjongTile.M1 to MahjongTile.M3), engine.availableReactions(north.uuid)?.chiiPairs)
+        assertEquals(null, engine.availableReactions(south.uuid))
+        assertEquals(null, engine.availableReactions(west.uuid))
+    }
+
+    @Test
     fun `placement order uses current seat wind for tie breaks`() {
         val players = listOf(
             RiichiPlayerState("East", "east"),


### PR DESCRIPTION
## Summary
- change riichi turn progression to counterclockwise order
- update claim resolution and chii side mapping to match the new turn order
- add focused tests for counterclockwise turn advance and chii eligibility

## Testing
- built locally with ./gradlew assemble -x test