### PR TITLE
docs: complete legal credits and notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > This project was created entirely by AI.
 
+> **NOT AN OFFICIAL MINECRAFT PRODUCT. NOT APPROVED BY OR ASSOCIATED WITH MOJANG OR MICROSOFT.**
+>
+> `Mahjong Soul` / `雀魂` is referenced only to describe compatible rules and visual style. MahjongPaper is not affiliated with or endorsed by Mahjong Soul or its rightsholders. All product names and trademarks belong to their respective owners.
+
 Chinese documentation: [README.zh-CN.md](./README.zh-CN.md)
 Chinese gameplay and operations wiki: [docs/wiki.zh-CN.md](./docs/wiki.zh-CN.md)
 Contributor notes: [CONTRIBUTING.md](./CONTRIBUTING.md)
@@ -250,19 +254,46 @@ MahjongPaper currently uses CraftEngine for:
 - tracked entity culling integration
 - furniture interaction routing for table interaction
 
-## Resource Assets
+## Credits, Assets, and Upstream Projects
 
-The assets in [resourcepack](./resourcepack) are packaged and delivered through the exported CraftEngine bundle.
+MahjongPaper is an independent rewrite/port and does not claim ownership of third-party code, artwork, recordings, names, or trademarks. The project-level MIT license applies only to material for which this repository's authors can grant that license; third-party components remain under their own licenses or terms.
 
-## Upstream References
+### Code, rules, and platforms
 
-- `MahjongCraft`: <https://github.com/EndlessCheng/MahjongCraft>
-- `MahjongPlay`: <https://github.com/7yunluo/MahjongPlay>
-- `mahjong-utils`: <https://github.com/ssttkkl/mahjong-utils>
-- `Paper`: <https://papermc.io/software/paper>
-- `CraftEngine`: <https://github.com/Xiao-MoMi/craft-engine>
-- `GB-Mahjong`: <https://github.com/zheng-fan/GB-Mahjong>
-- `mahjong_graphic`: <https://github.com/lietxia/mahjong_graphic>
+| Project | Relationship to MahjongPaper | License / terms |
+| --- | --- | --- |
+| [MahjongCraft](https://github.com/doublemoon1119/MahjongCraft), by `doublemoon1119` | Original Fabric mod; primary gameplay/architecture inspiration and source of reused tile textures and base item models | [MIT](https://github.com/doublemoon1119/MahjongCraft/blob/main/LICENSE) |
+| [MahjongPlay](https://github.com/7yunluo/MahjongPlay), by `7yunluo` | Paper-plugin implementation reference | [MIT](https://github.com/7yunluo/MahjongPlay/blob/main/LICENSE) |
+| [mahjong-utils](https://github.com/ssttkkl/mahjong-utils), by `ssttkkl` | Direct runtime library for Riichi hand evaluation and scoring | [MIT](https://github.com/ssttkkl/mahjong-utils/blob/main/LICENSE) |
+| [GB-Mahjong](https://github.com/zheng-fan/GB-Mahjong), by Zheng Fan | Vendored C++ source compiled into the bundled GB rules JNI library | [MIT; local copy](./native/gbmahjong/vendor/GB-Mahjong/LICENSE) |
+| [Paper](https://github.com/PaperMC/Paper) / [Folia](https://github.com/PaperMC/Folia) | Supported server platforms and APIs; supplied separately by the server operator | Their respective upstream licenses |
+| [CraftEngine](https://github.com/Xiao-MoMi/craft-engine) | Required external runtime plugin for custom items, furniture, interaction, culling, and resource delivery; not bundled | [GPL-3.0](https://github.com/Xiao-MoMi/craft-engine/blob/main/LICENSE) |
+| [Adventure](https://github.com/PaperMC/adventure) | Text/component API supplied by Paper | [Apache-2.0](https://github.com/PaperMC/adventure/blob/main/5/license.txt) |
+
+### Resource-pack artwork and sound
+
+The assets in [resourcepack](./resourcepack) are packaged into the exported CraftEngine bundle. The authoritative per-file/source notice is [resourcepack/ATTRIBUTION.md](./resourcepack/ATTRIBUTION.md); keep that file with every redistributed bundle.
+
+- Mahjong tile textures and base item models are reused from [MahjongCraft](https://github.com/doublemoon1119/MahjongCraft) under MIT. The related tile-art lineage also credits [mahjong_graphic](https://github.com/lietxia/mahjong_graphic) by `lietxia`, released under the M+ Fonts License; its documentation identifies partial lineage from [I.Mahjong](https://github.com/SyaoranHinata/I.Mahjong) and GL-MahjongTile.
+- Tile/table sound recordings are adapted from Freesound uploads `329098`, `329099`, and `329100` by **Macif**, `197868` by **Millavsb**, and `745024` by **poenia**, each marked [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/). Direct source links and file mappings are in the attribution file.
+- Riichi action voices use `chii_01.wav`, `pon_01.wav`, `kan_01.wav`, `ri-chi_01.wav`, and `ron_01.wav` from [Amitaro's Voice Material Studio](https://amitaro.net/voice/game_01/) under the studio's [custom terms](https://amitaro.net/voice/voice_rule/), not under MIT or CC0.
+
+Required voice credit:
+
+> Voice: Amitaro's Voice Material Studio (<https://amitaro.net/>)<br>
+> 音声素材：あみたろの声素材工房 (<https://amitaro.net/>)
+
+Redistribution of the Amitaro voice files is permitted only as part of a work such as this plugin/resource bundle, subject to the current Amitaro terms. Redistributors must preserve the credit and terms link/readme, must not offer the recordings as a standalone voice/sound pack, and should complete the required post-release usage report within the period stated by those terms. A Japanese report draft is maintained at [docs/amitaro-usage-report.ja.md](./docs/amitaro-usage-report.ja.md).
+
+### Runtime libraries
+
+The build declares the following direct runtime libraries; they are separate works and remain under their own licenses: [MariaDB Connector/J](https://github.com/mariadb-corporation/mariadb-connector-j) (LGPL-2.1), [MySQL Connector/J](https://github.com/mysql/mysql-connector-j) (GPL-2.0 with Oracle's additional permissions and Universal FOSS Exception), [H2](https://github.com/h2database/h2database) (MPL-2.0 or EPL-1.0), [HikariCP](https://github.com/brettwooldridge/HikariCP) (Apache-2.0), [Caffeine](https://github.com/ben-manes/caffeine) (Apache-2.0), [Kotlin](https://github.com/JetBrains/kotlin) (Apache-2.0), and [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) (Apache-2.0). Paper's plugin loader resolves the Maven libraries listed in [MahjongPaperLoader.java](./src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperLoader.java); [build.gradle.kts](./build.gradle.kts) is the authoritative direct dependency/version list.
+
+Platform-native releases also include the compiled GB-Mahjong JNI bridge. A Windows release may include `libwinpthread-1.dll` from [mingw-w64 winpthreads](https://github.com/mingw-w64/mingw-w64/tree/master/mingw-w64-libraries/winpthreads), under its upstream MIT/BSD-style notice. GCC runtime portions, when linked by the native build, are covered by GPL-3.0 plus the [GCC Runtime Library Exception 3.1](https://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html).
+
+### Trademark and affiliation notice
+
+Minecraft is a trademark of Microsoft. MahjongPaper is independently developed and is not an official Minecraft product, nor approved by or associated with Mojang or Microsoft. References to Mahjong Soul / 雀魂 describe rules or style only and do not imply affiliation, sponsorship, or endorsement. The names and marks of all upstream projects remain the property of their respective owners.
 
 ## Community
 
@@ -273,4 +304,4 @@ The assets in [resourcepack](./resourcepack) are packaged and delivered through 
 
 ## License
 
-This project is licensed under the [MIT License](./LICENSE).
+Original MahjongPaper code and project-created assets are licensed under the [MIT License](./LICENSE), except where a file or the notices above identify different terms. Third-party notices and licenses must be retained when redistributing their material. This summary is provided for attribution and project hygiene; it is not legal advice and does not replace the governing license texts or service terms.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,10 @@
 
 > 本项目完全由 AI 创作。
 
+> **本项目不是官方 MINECRAFT 产品，未经 MOJANG 或 MICROSOFT 批准，也与其无关联。**
+>
+> 文档中的 `Mahjong Soul` / `雀魂` 仅用于描述兼容的规则和视觉风格。MahjongPaper 与雀魂及其权利人无关联，也未获其背书。各产品名称和商标归各自权利人所有。
+
 英文说明见 [README.md](./README.md)。
 贡献与代码边界说明见 [CONTRIBUTING.md](./CONTRIBUTING.md)。
 
@@ -244,14 +248,47 @@
 - tracked entity 剔除桥接
 - 牌桌交互事件路由
 
-## CraftEngine 资源
+## 致谢、资源与上游项目
 
-[resourcepack](./resourcepack) 中的资源只作为 CraftEngine bundle 的源素材，由 CraftEngine 负责打包和下发。
+MahjongPaper 是独立重写/移植项目，不主张拥有第三方代码、美术、录音、名称或商标。项目根目录的 MIT 许可证只适用于本项目作者有权授权的内容；第三方组件仍受各自的许可证或使用条款约束。
 
-## 上游参考
+### 代码、规则与平台
 
-- `MahjongCraft`
-- `MahjongPlay`: <https://github.com/7yunluo/MahjongPlay>
-- `mahjong-utils`: <https://github.com/ssttkkl/mahjong-utils>
-- `Paper`
-- `CraftEngine`
+| 项目 | 与 MahjongPaper 的关系 | 许可证 / 条款 |
+| --- | --- | --- |
+| [MahjongCraft](https://github.com/doublemoon1119/MahjongCraft)，作者 `doublemoon1119` | 原始 Fabric Mod；主要玩法/架构灵感来源，也是本项目复用麻将牌纹理和基础物品模型的直接来源 | [MIT](https://github.com/doublemoon1119/MahjongCraft/blob/main/LICENSE) |
+| [MahjongPlay](https://github.com/7yunluo/MahjongPlay)，作者 `7yunluo` | Paper 插件实现参考 | [MIT](https://github.com/7yunluo/MahjongPlay/blob/main/LICENSE) |
+| [mahjong-utils](https://github.com/ssttkkl/mahjong-utils)，作者 `ssttkkl` | 立直麻将和牌判定与计分的直接运行时库 | [MIT](https://github.com/ssttkkl/mahjong-utils/blob/main/LICENSE) |
+| [GB-Mahjong](https://github.com/zheng-fan/GB-Mahjong)，作者 Zheng Fan | 以源码形式内置，编译进随包发行的国标麻将 JNI 原生库 | [MIT；仓库内许可证](./native/gbmahjong/vendor/GB-Mahjong/LICENSE) |
+| [Paper](https://github.com/PaperMC/Paper) / [Folia](https://github.com/PaperMC/Folia) | 支持的服务器平台与 API，由服务器运营者另行提供 | 以各自上游许可证为准 |
+| [CraftEngine](https://github.com/Xiao-MoMi/craft-engine) | 自定义物品、家具、交互、剔除和资源下发所需的外部运行时插件；本项目不内置该插件 | [GPL-3.0](https://github.com/Xiao-MoMi/craft-engine/blob/main/LICENSE) |
+| [Adventure](https://github.com/PaperMC/adventure) | 由 Paper 提供的文本/组件 API | [Apache-2.0](https://github.com/PaperMC/adventure/blob/main/5/license.txt) |
+
+### 资源包美术与音效
+
+[resourcepack](./resourcepack) 中的素材会被打包到导出的 CraftEngine bundle 中。每个文件的来源、授权和用途以 [resourcepack/ATTRIBUTION.md](./resourcepack/ATTRIBUTION.md) 为准；二次分发时必须保留该文件。
+
+- 麻将牌纹理和基础物品模型复用自 [MahjongCraft](https://github.com/doublemoon1119/MahjongCraft)，适用 MIT 许可证。相关牌面美术谱系同时致谢 `lietxia` 的 [mahjong_graphic](https://github.com/lietxia/mahjong_graphic)（M+ 字体授权条款）；其文档还记录了部分图形源自 [I.Mahjong](https://github.com/SyaoranHinata/I.Mahjong) 与 GL-MahjongTile。
+- 真实牌/桌面音效取材自 Freesound：**Macif** 的 `329098`、`329099`、`329100`，**Millavsb** 的 `197868`，以及 **poenia** 的 `745024`；这些录音均标记为 [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)。原始链接和文件对应关系详见资源署名文件。
+- 立直模式的动作人声 `chii_01.wav`、`pon_01.wav`、`kan_01.wav`、`ri-chi_01.wav` 和 `ron_01.wav` 来自 [あみたろの声素材工房](https://amitaro.net/voice/game_01/)，适用该网站的[专用使用条款](https://amitaro.net/voice/voice_rule/)，**不适用**本项目的 MIT 或 CC0 授权。
+
+必须保留的人声素材署名：
+
+> 音声素材：あみたろの声素材工房 (<https://amitaro.net/>)<br>
+> Voice: Amitaro's Voice Material Studio (<https://amitaro.net/>)
+
+あみたろ人声只能在遵守当前条款的前提下，作为插件/资源 bundle 这类作品的组成部分分发。二次分发者必须保留署名和条款链接/Readme，不得将录音作为独立人声包或音效包提供，并应当按条款规定的期限完成发布后使用报告。日文报告草稿见 [docs/amitaro-usage-report.ja.md](./docs/amitaro-usage-report.ja.md)。
+
+### 直接运行时库
+
+构建脚本声明了以下直接运行时库；它们是独立作品，仍适用各自许可证：[MariaDB Connector/J](https://github.com/mariadb-corporation/mariadb-connector-j) (LGPL-2.1)、[MySQL Connector/J](https://github.com/mysql/mysql-connector-j) (GPL-2.0，附 Oracle 额外许可与 Universal FOSS Exception)、[H2](https://github.com/h2database/h2database) (MPL-2.0 或 EPL-1.0)、[HikariCP](https://github.com/brettwooldridge/HikariCP) (Apache-2.0)、[Caffeine](https://github.com/ben-manes/caffeine) (Apache-2.0)、[Kotlin](https://github.com/JetBrains/kotlin) (Apache-2.0) 以及 [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) (Apache-2.0)。Paper 插件加载器会解析 [MahjongPaperLoader.java](./src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperLoader.java) 中列出的 Maven 库；[build.gradle.kts](./build.gradle.kts) 是直接依赖和版本的准确来源。
+
+各平台发行包还包含编译后的 GB-Mahjong JNI 桥接库。Windows 发行包可能包含 [mingw-w64 winpthreads](https://github.com/mingw-w64/mingw-w64/tree/master/mingw-w64-libraries/winpthreads) 的 `libwinpthread-1.dll`，适用其上游 MIT/BSD 类许可通知。原生构建链接的 GCC 运行时部分适用 GPL-3.0 及 [GCC Runtime Library Exception 3.1](https://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html)。
+
+### 商标与无关联声明
+
+Minecraft 是 Microsoft 的商标。MahjongPaper 为独立开发项目，不是官方 Minecraft 产品，未经 Mojang 或 Microsoft 批准，也与其无关联。对 Mahjong Soul / 雀魂的引用只用于描述规则或风格，不构成关联、赞助或背书。各上游项目的名称和商标归各自权利人所有。
+
+## 许可证
+
+MahjongPaper 原创代码和项目自制资源适用 [MIT License](./LICENSE)，但文件或上述通知另有标注的除外。二次分发第三方内容时必须保留对应署名、许可证和使用条款。本节只用于项目署名和合规整理，不构成法律意见，也不替代具有约束力的许可证或服务条款原文。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,28 @@
+# Third-Party Notices
+
+MahjongPaper's own code and project-created assets are licensed under the root [MIT License](./LICENSE). That license does not relicense third-party code, assets, recordings, names, or trademarks identified below.
+
+## Material included in release artifacts
+
+- **GB-Mahjong** by Zheng Fan is vendored and compiled into the GB rules JNI library under the MIT License. Copyright (c) 2019-2020 Zheng Fan `<i@fanzheng.org>`. The complete license is stored at `native/gbmahjong/vendor/GB-Mahjong/LICENSE` and packaged as `META-INF/licenses/GB-Mahjong-LICENSE.txt`.
+- Mahjong tile textures and base item models are reused from **MahjongCraft** by `doublemoon1119` under the MIT License. Copyright (c) 2021 doublemoon1119. The complete notice is included in `resourcepack/ATTRIBUTION.md` and packaged as `META-INF/RESOURCEPACK_ATTRIBUTION.md`.
+- Related tile-art provenance credits **mahjong_graphic** by `lietxia` and **I.Mahjong** by SyaoranHinata under the M+ Fonts License. Their documentation identifies GL-MahjongTile as earlier artwork/font lineage.
+- Tile/table recordings are adapted from Freesound uploads `329098`, `329099`, and `329100` by **Macif**, `197868` by **Millavsb**, and `745024` by **poenia**, each marked CC0 1.0. File-level mappings and source URLs are in `resourcepack/ATTRIBUTION.md`.
+- Riichi action voices are derived from `chii_01.wav`, `pon_01.wav`, `kan_01.wav`, `ri-chi_01.wav`, and `ron_01.wav` by **Amitaro's Voice Material Studio** under its custom terms, not MIT or CC0.
+- Windows artifacts may include `libwinpthread-1.dll` from **mingw-w64 winpthreads**. Its MIT/BSD-style notice is packaged as `META-INF/licenses/winpthreads-COPYING.txt`.
+- GCC runtime portions linked by the native build are licensed under GPL-3.0 with the GCC Runtime Library Exception 3.1: <https://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html>.
+
+Required Amitaro credit:
+
+> Voice: Amitaro's Voice Material Studio (<https://amitaro.net/>)<br>
+> 音声素材：あみたろの声素材工房 (<https://amitaro.net/>)
+
+The Amitaro recordings may be redistributed only as part of a work such as this plugin/resource bundle and subject to the current terms at <https://amitaro.net/voice/voice_rule/>. Preserve the credit and terms link/readme, do not distribute the recordings as a standalone voice or sound pack, and complete any required post-release usage report.
+
+## Separate platforms and runtime libraries
+
+Paper, Folia, and CraftEngine are separate server components supplied by the server operator. Paper's plugin loader resolves mahjong-utils, MariaDB Connector/J, MySQL Connector/J, H2, HikariCP, Caffeine, Kotlin, and kotlinx.serialization as separate libraries under their respective upstream licenses. See the README and build files for links, versions, and license identifiers.
+
+## Trademark and affiliation notice
+
+**NOT AN OFFICIAL MINECRAFT PRODUCT. NOT APPROVED BY OR ASSOCIATED WITH MOJANG OR MICROSOFT.** References to Mahjong Soul / 雀魂 describe rules or style only and do not imply affiliation, sponsorship, or endorsement. All names and trademarks belong to their respective owners.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,25 @@ tasks {
         inputs.property("kotlinSerializationVersion", kotlinSerializationVersion)
         from(generatedResourcesDir)
         from(generatedNativeResourcesDir)
+        from(rootProject.file("LICENSE")) {
+            into("META-INF")
+            rename { "LICENSE.txt" }
+        }
+        from(rootProject.file("THIRD_PARTY_NOTICES.md")) {
+            into("META-INF")
+        }
+        from(rootProject.file("resourcepack/ATTRIBUTION.md")) {
+            into("META-INF")
+            rename { "RESOURCEPACK_ATTRIBUTION.md" }
+        }
+        from(rootProject.file("native/gbmahjong/vendor/GB-Mahjong/LICENSE")) {
+            into("META-INF/licenses")
+            rename { "GB-Mahjong-LICENSE.txt" }
+        }
+        from(rootProject.file("native/gbmahjong/WINPTHREADS-COPYING.txt")) {
+            into("META-INF/licenses")
+            rename { "winpthreads-COPYING.txt" }
+        }
         filesMatching(listOf("plugin.yml", "paper-plugin.yml")) {
             expand(
                 "version" to project.version,

--- a/native/gbmahjong/WINPTHREADS-COPYING.txt
+++ b/native/gbmahjong/WINPTHREADS-COPYING.txt
@@ -1,0 +1,50 @@
+Copyright (c) 2011 mingw-w64 project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Parts of this library are derived from the POSIX Threads library for Microsoft
+Windows:
+
+Copyright (c) 2010 Lockless Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of Lockless Inc. nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+Upstream notice: https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-libraries/winpthreads/COPYING

--- a/resourcepack/ATTRIBUTION.md
+++ b/resourcepack/ATTRIBUTION.md
@@ -3,6 +3,12 @@ This resource pack reuses Mahjong tile textures and base item models from the up
 - Project: `doublemoon1119/MahjongCraft`
 - Repository: https://github.com/doublemoon1119/MahjongCraft
 - License: MIT
+- Copyright: Copyright (c) 2021 doublemoon1119
+
+Related tile-art provenance retained by Paper-plugin upstreams:
+
+- `lietxia/mahjong_graphic`: https://github.com/lietxia/mahjong_graphic (M+ Fonts License)
+- `SyaoranHinata/I.Mahjong`: https://github.com/SyaoranHinata/I.Mahjong (M+ Fonts License); its documentation identifies GL-MahjongTile as an earlier source.
 
 The additional `assets/mahjongcraft/items/**` files and the `mahjong_tile_back.json` item model were added for Paper `item_model` support.
 
@@ -13,7 +19,7 @@ Dice textures, table textures, dice item models, and the table furniture model a
 The sound effects under `assets/mahjongcraft/sounds/` use low-risk redistributable sources:
 
 - Real tile/table sounds are from Freesound recordings marked Creative Commons 0 (CC0 1.0).
-- Action call voices are from Amitaro's Voice Material Studio. These are not CC0; use requires credit, terms-link/readme, and a post-release usage report when redistributed in a Minecraft/CraftEngine bundle.
+- Action call voices are from Amitaro's Voice Material Studio. These are not CC0 or MIT; use requires credit, a terms link/readme, and a post-release usage report within the period stated by the current Amitaro terms when redistributed in a Minecraft/CraftEngine bundle.
 - GB and Sichuan variant-specific sounds are derived only from the CC0 Freesound recordings listed below; they do not include third-party voice material.
 - The T-STUDIO Mahjong sound pack is intentionally not included because its redistribution terms are not a good fit for a merged CraftEngine resource bundle.
 
@@ -49,3 +55,30 @@ Sources:
 Required voice credit:
 
 - Voice: Amitaro's Voice Material Studio (https://amitaro.net/)
+- 音声素材：あみたろの声素材工房 (https://amitaro.net/)
+
+The Amitaro recordings may be redistributed only as part of a work such as this plugin/resource bundle and subject to the current terms. Do not redistribute them as a standalone voice or sound pack. Preserve this attribution and the terms link/readme. The repository's MIT license does not relicense these recordings.
+
+## MahjongCraft MIT License Notice
+
+MIT License
+
+Copyright (c) 2021 doublemoon1119
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What changed

- replaces the broken MahjongCraft link with the actual `doublemoon1119/MahjongCraft` upstream
- adds complete code, platform, runtime-library, artwork, audio, and trademark credits in both READMEs
- documents Amitaro voice attribution, redistribution limits, terms link, and usage-report requirement
- adds packaged third-party notices, the GB-Mahjong license, resource-pack attribution, and winpthreads notice to release JAR resources

## Why

The previous README mixed reference projects with redistributed components and did not make third-party license boundaries or required voice attribution prominent enough. Release JARs also needed self-contained notices.

## Impact

No gameplay behavior changes. Users and redistributors get explicit provenance, license boundaries, required credits, and trademark disclaimers; release artifacts retain the relevant notices.

## Checks

- `git diff --cached --check` passed before commit
- local Kotlin/Java compilation, native GB-Mahjong compilation, resource generation, and JAR assembly completed
- full local test execution was interrupted by Windows virtual-memory exhaustion; GitHub Actions is the authoritative clean build for this PR