### PR TITLE
fix: restore supported Paper runtime foundations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for helping improve MahjongEngine.
 ## Local Setup
 
 1. Fork and clone the repository.
-2. Use JDK 21+ for the default build. The released jar is built with Java 17 bytecode and `api-version: 1.20`, so a single jar runs on Paper/Folia 1.20.1 through 26.2.
+2. Use JDK 21+ for the default build. The released jar uses Java 21 bytecode and `api-version: 1.20`, so its server runtime must also provide Java 21 or newer.
 3. Build the project:
 
 ```powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         # Gate the build on tests so a native-platform build never ships a jar
         # with broken Java/Kotlin. Native tasks are skipped here; they are
         # exercised in the build-platform matrix below.
-        run: ./gradlew test "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=17" -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
+        run: ./gradlew test "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=21" -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
 
   build-platform:
     needs: test-gate
@@ -126,7 +126,7 @@ jobs:
         # Pin to the lowest supported Paper baseline so the released jar stays runtime-compatible
         # with Paper/Folia 1.20.1 -> 26.2. PaperCompatibility handles newer APIs at runtime.
         # Quote each -P argument because PowerShell on Windows runners mis-parses `1.20.1-R0.1-SNAPSHOT`.
-        run: ${{ matrix.gradle }} build -x test "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaTarget=17" "-PmahjongJavaToolchain=25"
+        run: ${{ matrix.gradle }} build -x test "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaTarget=21" "-PmahjongJavaToolchain=25"
 
       - name: Verify artifact compatibility (Linux only)
         if: runner.os == 'Linux'
@@ -147,7 +147,7 @@ jobs:
           python3 - "$JAR" <<'PY'
           import sys, zipfile, struct
           jar = sys.argv[1]
-          allowed_max = 61  # Java 17
+          allowed_max = 65  # Java 21
           bad = []
           with zipfile.ZipFile(jar) as z:
               for n in z.namelist():
@@ -161,11 +161,11 @@ jobs:
                   if major > allowed_max:
                       bad.append((n, major))
           if bad:
-              print(f'::error::Found {len(bad)} class files compiled above Java 17:')
+              print(f'::error::Found {len(bad)} class files compiled above Java 21:')
               for n, m in bad[:20]:
                   print(f'  {n}: major={m} (Java {m-44})')
               sys.exit(1)
-          print('All classes compiled to Java 17 or lower.')
+          print('All classes compiled to Java 21 or lower.')
           PY
 
       - name: Upload platform jar
@@ -237,3 +237,181 @@ jobs:
         with:
           name: mahjong-paper-jars
           path: build/universal/*.jar
+
+  compatibility-smoke:
+    name: Standard Paper ${{ matrix.minecraft }} + latest CraftEngine Paper
+    needs: build-platform
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - minecraft: "1.20.1"
+            java: "21"
+            paper_file: paper-1.20.1-196.jar
+            paper_url: https://fill-data.papermc.io/v1/objects/234a9b32098100c6fc116664d64e36ccdb58b5b649af0f80bcccb08b0255eaea/paper-1.20.1-196.jar
+            paper_sha256: 234a9b32098100c6fc116664d64e36ccdb58b5b649af0f80bcccb08b0255eaea
+          - minecraft: "1.20.4"
+            java: "21"
+            paper_file: paper-1.20.4-499.jar
+            paper_url: https://fill-data.papermc.io/v1/objects/cabed3ae77cf55deba7c7d8722bc9cfd5e991201c211665f9265616d9fe5c77b/paper-1.20.4-499.jar
+            paper_sha256: cabed3ae77cf55deba7c7d8722bc9cfd5e991201c211665f9265616d9fe5c77b
+          - minecraft: "1.21.1"
+            java: "21"
+            paper_file: paper-1.21.1-133.jar
+            paper_url: https://fill-data.papermc.io/v1/objects/39bd8c00b9e18de91dcabd3cc3dcfa5328685a53b7187a2f63280c22e2d287b9/paper-1.21.1-133.jar
+            paper_sha256: 39bd8c00b9e18de91dcabd3cc3dcfa5328685a53b7187a2f63280c22e2d287b9
+          - minecraft: "26.1.2"
+            java: "25"
+            paper_file: paper-26.1.2-74.jar
+            paper_url: https://fill-data.papermc.io/v1/objects/1d70b1dab9cf4a6de615209a536f3a45a2186240253c428213ce2188ab95e5f7/paper-26.1.2-74.jar
+            paper_sha256: 1d70b1dab9cf4a6de615209a536f3a45a2186240253c428213ce2188ab95e5f7
+
+    steps:
+      - name: Set up server JDK ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - name: Download Linux plugin artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: mahjong-paper-jar-linux
+          path: artifacts/linux
+
+      - name: Prepare checksum-locked standard server.jar stack
+        shell: bash
+        env:
+          PAPER_URL: ${{ matrix.paper_url }}
+          PAPER_FILE: ${{ matrix.paper_file }}
+          PAPER_SHA256: ${{ matrix.paper_sha256 }}
+          CRAFTENGINE_URL: https://cdn.modrinth.com/data/tRX6FMfQ/versions/Len451or/craft-engine-paper-plugin-26.7.3.jar
+          CRAFTENGINE_SHA512: e87351417e4f99504cf0a8868bad03a88b12bc9bda5c36f0ee4c7451e3525f08146b2130b61cd34b222ee41c38ca75aa9ced9ada65bc3540c80aa66c3d39d689
+        run: |
+          set -euo pipefail
+          mkdir -p smoke/plugins
+          curl --fail --location --retry 3 --output "smoke/$PAPER_FILE" "$PAPER_URL"
+          printf '%s  %s\n' "$PAPER_SHA256" "smoke/$PAPER_FILE" | sha256sum --check --strict
+          cp "smoke/$PAPER_FILE" smoke/server.jar
+
+          curl --fail --location --retry 3 \
+            --output smoke/plugins/craft-engine-paper-plugin-26.7.3.jar \
+            "$CRAFTENGINE_URL"
+          printf '%s  %s\n' \
+            "$CRAFTENGINE_SHA512" \
+            smoke/plugins/craft-engine-paper-plugin-26.7.3.jar \
+            | sha512sum --check --strict
+
+          PLUGIN_JAR="$(find artifacts/linux -type f -name '*.jar' ! -name '*-sources.jar' ! -name '*-dev.jar' | sort | head -n 1)"
+          test -n "$PLUGIN_JAR"
+          cp "$PLUGIN_JAR" smoke/plugins/mahjong-paper.jar
+          printf 'eula=true\n' > smoke/eula.txt
+          cat > smoke/server.properties <<'EOF'
+          online-mode=false
+          server-ip=127.0.0.1
+          server-port=25565
+          max-players=1
+          view-distance=3
+          simulation-distance=3
+          spawn-protection=0
+          allow-nether=false
+          generate-structures=false
+          enable-query=false
+          enable-rcon=false
+          EOF
+
+      - name: Cold-start, execute /mahjong help, and stop cleanly
+        shell: bash
+        working-directory: smoke
+        run: |
+          set -euo pipefail
+          mkfifo console.pipe
+          exec 3<>console.pipe
+          java -Xms512m -Xmx1g -jar server.jar --nogui <&3 >server.log 2>&1 &
+          SERVER_PID=$!
+
+          cleanup() {
+            if kill -0 "$SERVER_PID" 2>/dev/null; then
+              printf 'stop\n' >&3 || true
+              for _ in $(seq 1 30); do
+                kill -0 "$SERVER_PID" 2>/dev/null || break
+                sleep 1
+              done
+              kill "$SERVER_PID" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          READY=false
+          for _ in $(seq 1 240); do
+            if grep -Eq 'Done \([^)]+\)! For help' server.log; then
+              READY=true
+              break
+            fi
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo '::error::Paper exited before reaching the ready state'
+              cat server.log
+              exit 1
+            fi
+            sleep 1
+          done
+          if [[ "$READY" != true ]]; then
+            echo '::error::Paper did not become ready within 240 seconds'
+            cat server.log
+            exit 1
+          fi
+
+          grep -Eq '\[MahjongPaper\].*Enabling MahjongPaper v' server.log
+          grep -Eq '\[CraftEngine\].*Enabling CraftEngine v26\.7\.3' server.log
+
+          COMMAND_START=$(wc -l < server.log)
+          printf 'mahjong help\n' >&3
+          sleep 5
+          tail -n "+$((COMMAND_START + 1))" server.log > command.log
+          if grep -Eiq 'unknown command|unknown or incomplete command|command exception' command.log; then
+            echo '::error::The /mahjong command was not executable'
+            cat command.log
+            exit 1
+          fi
+          grep -Fq 'MahjongPaper' command.log
+
+          verify_library() {
+            local filename="$1"
+            local expected="$2"
+            local found
+            found="$(find libraries -type f -name "$filename" -print -quit)"
+            if [[ -z "$found" ]]; then
+              echo "::error::Loader did not resolve $filename"
+              exit 1
+            fi
+            printf '%s  %s\n' "$expected" "$found" | sha256sum --check --strict
+          }
+          verify_library sparrow-heart-0.72.jar a539b7b6db55a2369599b643e5b2d20ec12184ad2798eb858f17a64dcde1d7ea
+          verify_library sparrow-reflection-0.33.jar 7c34a0839650be8025634077656a00569cbedbad9999e03af3482391ccd14a93
+          verify_library asm-9.9.1.jar 6f3828a215c920059a5efa2fb55c233d6c54ec5cadca99ce1b1bdd10077c7ddd
+          verify_library caffeine-3.2.4.jar 9d9d2cfd681fd9272ded3d27c9930db12f89f732345975aa113ebc223bbf1224
+
+          printf 'stop\n' >&3
+          for _ in $(seq 1 60); do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 1
+          done
+          if kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo '::error::Paper did not stop cleanly within 60 seconds'
+            exit 1
+          fi
+          wait "$SERVER_PID"
+          trap - EXIT
+
+      - name: Upload compatibility evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: compatibility-smoke-${{ matrix.minecraft }}
+          path: |
+            smoke/server.log
+            smoke/command.log
+            smoke/logs/latest.log
+          if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,6 +365,20 @@ jobs:
 
           grep -Eq '\[MahjongPaper\].*Enabling MahjongPaper v' server.log
           grep -Eq '\[CraftEngine\].*Enabling CraftEngine v26\.7\.3' server.log
+          if grep -Eiq \
+            'Failed to enable CraftEngine|Error initializing CraftEngine|Cannot find proxied class|CraftEngine.*shutting down server' \
+            server.log; then
+            echo '::error::The latest CraftEngine Paper artifact failed to enable on this declared-compatible Paper version'
+            grep -Ein \
+              'Failed to enable CraftEngine|Error initializing CraftEngine|Cannot find proxied class|CraftEngine.*shutting down server' \
+              server.log || true
+            exit 1
+          fi
+          if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo '::error::Paper exited after plugin enablement'
+            cat server.log
+            exit 1
+          fi
 
           COMMAND_START=$(wc -l < server.log)
           printf 'mahjong help\n' >&3
@@ -375,7 +389,11 @@ jobs:
             cat command.log
             exit 1
           fi
-          grep -Fq 'MahjongPaper' command.log
+          if ! grep -Eq 'Only players can use this command|只有玩家可以使用' command.log; then
+            echo '::error::The console command was not dispatched to MahjongPaper'
+            cat command.log
+            exit 1
+          fi
 
           verify_library() {
             local filename="$1"

--- a/.github/workflows/performance-ab.yml
+++ b/.github/workflows/performance-ab.yml
@@ -187,7 +187,7 @@ jobs:
           base/gradlew -p base jmhJar --console plain --no-daemon
           -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
           "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT"
-          "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=17"
+          "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=21"
 
       - name: Build candidate JMH jar without privileged runtime credentials
         shell: bash
@@ -204,7 +204,7 @@ jobs:
           candidate/gradlew -p candidate jmhJar --console plain --no-daemon
           -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
           "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT"
-          "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=17"
+          "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=21"
 
       - name: Locate benchmark jars
         id: jars

--- a/.github/workflows/performance-infra.yml
+++ b/.github/workflows/performance-infra.yml
@@ -90,7 +90,7 @@ jobs:
           ./gradlew jmhJar --console plain --no-daemon
           -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
           "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT"
-          "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=17"
+          "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=21"
 
       - name: Run one smoke iteration for every protected benchmark
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         # Pin to the lowest supported Paper baseline so the released jar stays runtime-compatible
         # with Paper/Folia 1.20.1 -> 26.2. PaperCompatibility handles newer APIs at runtime.
         # Quote each -P argument because PowerShell on Windows runners mis-parses `1.20.1-R0.1-SNAPSHOT`.
-        run: ${{ matrix.gradle }} build -x test "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaTarget=17" "-PmahjongJavaToolchain=25"
+        run: ${{ matrix.gradle }} build -x test "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaTarget=21" "-PmahjongJavaToolchain=25"
 
       - name: Verify artifact compatibility (Linux only)
         if: runner.os == 'Linux'
@@ -98,7 +98,7 @@ jobs:
           python3 - "$JAR" <<'PY'
           import sys, zipfile, struct
           jar = sys.argv[1]
-          allowed_max = 61  # Java 17
+          allowed_max = 65  # Java 21
           bad = []
           with zipfile.ZipFile(jar) as z:
               for n in z.namelist():
@@ -112,11 +112,11 @@ jobs:
                   if major > allowed_max:
                       bad.append((n, major))
           if bad:
-              print(f'::error::Found {len(bad)} class files compiled above Java 17:')
+              print(f'::error::Found {len(bad)} class files compiled above Java 21:')
               for n, m in bad[:20]:
                   print(f'  {n}: major={m} (Java {m-44})')
               sys.exit(1)
-          print('All classes compiled to Java 17 or lower.')
+          print('All classes compiled to Java 21 or lower.')
           PY
 
       - name: Upload platform jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         # Pin to the lowest supported Paper baseline so the released jar stays
         # runtime-compatible with Paper/Folia 1.20.1 -> 26.2. Skip native tasks
         # on non-Linux runners where the CMake toolchain may not be configured.
-        run: ${{ matrix.gradle }} ${{ matrix.test_task }} "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=17" -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
+        run: ${{ matrix.gradle }} ${{ matrix.test_task }} "-PmahjongPaperDevBundle=1.20.1-R0.1-SNAPSHOT" "-PmahjongJavaToolchain=25" "-PmahjongJavaTarget=21" -x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative
 
       - name: Upload test reports
         if: always()

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Contributor notes: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Current Scope
 
+MahjongPaper requires a Java 21 or newer server runtime and build JDK.
+
 The current branch already supports playable Riichi Mahjong, GB Mahjong, and Sichuan Mahjong flows on Paper/Folia:
 
 - lobby-style tables that can persist across restart

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -21,7 +21,14 @@ The Amitaro recordings may be redistributed only as part of a work such as this 
 
 ## Separate platforms and runtime libraries
 
-Paper, Folia, and CraftEngine are separate server components supplied by the server operator. Paper's plugin loader resolves mahjong-utils, MariaDB Connector/J, MySQL Connector/J, H2, HikariCP, Caffeine, Kotlin, and kotlinx.serialization as separate libraries under their respective upstream licenses. See the README and build files for links, versions, and license identifiers.
+Paper, Folia, and CraftEngine are separate server components supplied by the server operator. Paper's plugin loader resolves mahjong-utils, MariaDB Connector/J, MySQL Connector/J, H2, HikariCP, Caffeine, Kotlin, kotlinx.serialization, and the Sparrow libraries below as separate libraries under their respective upstream licenses. See the README and build files for links, versions, and license identifiers.
+
+The distribution also uses the following Xiao-MoMi ecosystem libraries:
+
+- **sparrow-heart 0.72**, Copyright (c) 2024 XiaoMoMi, under the MIT License, is resolved by Paper's plugin loader: <https://github.com/Xiao-MoMi/sparrow-heart>.
+- **sparrow-reflection 0.33** under the GNU General Public License v3.0 is resolved by Paper's plugin loader: <https://github.com/Xiao-MoMi/sparrow-reflection>.
+- **Mapping-IO 0.8.0** by FabricMC under the Apache License 2.0 is bundled by the upstream Sparrow Reflection artifact: <https://github.com/FabricMC/mapping-io>.
+- **ASM 9.9.1** under the BSD 3-Clause License is resolved by Paper's plugin loader: <https://gitlab.ow2.org/asm/asm>.
 
 ## Trademark and affiliation notice
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,7 @@
 import dev.detekt.gradle.Detekt
+import org.gradle.api.tasks.testing.Test
+import top.ellan.mahjong.build.MahjongBuildConfiguration
+import top.ellan.mahjong.build.MahjongBuildInputs
 import top.ellan.mahjong.build.MahjongTaskRegistration
 
 plugins {
@@ -21,12 +24,16 @@ val paperDevBundleVersion =
         .orElse(minimumPaperDevBundleVersion)
         .get()
 val paperApiVersion = "1.20"
+val minimumJavaVersion = 21
 val javaTargetVersion =
     providers
         .gradleProperty("mahjongJavaTarget")
         .map(String::toInt)
-        .orElse(17)
+        .orElse(minimumJavaVersion)
         .get()
+require(javaTargetVersion >= minimumJavaVersion) {
+    "mahjongJavaTarget must be Java $minimumJavaVersion or newer (was $javaTargetVersion)"
+}
 val toolchainJavaVersion =
     providers
         .gradleProperty("mahjongJavaToolchain")
@@ -40,18 +47,18 @@ val mysqlVersion = "9.7.0"
 val h2Version = "2.4.240"
 val hikariVersion = "7.1.0"
 val caffeineVersion = "3.2.4"
+val sparrowHeartVersion = "0.72"
+val sparrowReflectionVersion = "0.33"
+val asmVersion = "9.9.1"
 val adventureVersion = "4.14.0"
 val junitVersion = "6.1.1"
+val mockitoVersion = "5.23.0"
 val testcontainersVersion = "1.21.4"
 val generatedResourcesDir = layout.buildDirectory.dir("generated/resources/mahjong")
 val generatedNativeResourcesDir = layout.buildDirectory.dir("generated/resources/native")
+val mockitoAgent = configurations.create("mockitoAgent")
 
-repositories {
-    mavenCentral()
-    maven("https://repo.papermc.io/repository/maven-public/")
-    maven("https://repo.codemc.io/repository/maven-releases/")
-    maven("https://jitpack.io")
-}
+MahjongBuildConfiguration.configureRepositories(project)
 
 val codegenTasks =
     MahjongTaskRegistration.registerCodegenTasks(
@@ -79,15 +86,23 @@ dependencies {
     implementation("com.h2database:h2:$h2Version")
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
+    compileOnly("net.momirealms:sparrow-heart:$sparrowHeartVersion")
+    compileOnly("net.momirealms:sparrow-reflection:$sparrowReflectionVersion")
+    compileOnly("org.ow2.asm:asm:$asmVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinRuntimeVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion")
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
-    testImplementation("org.mockito:mockito-core:5.23.0")
-    testImplementation("org.mockito:mockito-inline:5.2.0")
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    mockitoAgent("org.mockito:mockito-core:$mockitoVersion") {
+        isTransitive = false
+    }
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:junit-jupiter:$testcontainersVersion")
     testImplementation("org.testcontainers:mariadb:$testcontainersVersion")
+    testImplementation("net.momirealms:sparrow-heart:$sparrowHeartVersion")
+    testImplementation("net.momirealms:sparrow-reflection:$sparrowReflectionVersion")
+    testImplementation("org.ow2.asm:asm:$asmVersion")
     testImplementation("net.kyori:adventure-api")
     testImplementation("net.kyori:adventure-text-minimessage")
     testImplementation("net.kyori:adventure-text-serializer-plain")
@@ -126,57 +141,30 @@ tasks {
         }
     }
 
-    withType<JavaCompile>().configureEach {
-        options.encoding = Charsets.UTF_8.name()
-        options.release.set(javaTargetVersion)
-    }
-
-    processResources {
-        dependsOn(codegenTasks + nativeTasks)
-        filteringCharset = Charsets.UTF_8.name()
-        inputs.property("pluginVersion", project.version.toString())
-        inputs.property("paperApiVersion", paperApiVersion)
-        inputs.property("mahjongUtilsVersion", mahjongUtilsVersion)
-        inputs.property("mariadbVersion", mariadbVersion)
-        inputs.property("h2Version", h2Version)
-        inputs.property("hikariVersion", hikariVersion)
-        inputs.property("kotlinRuntimeVersion", kotlinRuntimeVersion)
-        inputs.property("kotlinSerializationVersion", kotlinSerializationVersion)
-        from(generatedResourcesDir)
-        from(generatedNativeResourcesDir)
-        from(rootProject.file("LICENSE")) {
-            into("META-INF")
-            rename { "LICENSE.txt" }
-        }
-        from(rootProject.file("THIRD_PARTY_NOTICES.md")) {
-            into("META-INF")
-        }
-        from(rootProject.file("resourcepack/ATTRIBUTION.md")) {
-            into("META-INF")
-            rename { "RESOURCEPACK_ATTRIBUTION.md" }
-        }
-        from(rootProject.file("native/gbmahjong/vendor/GB-Mahjong/LICENSE")) {
-            into("META-INF/licenses")
-            rename { "GB-Mahjong-LICENSE.txt" }
-        }
-        from(rootProject.file("native/gbmahjong/WINPTHREADS-COPYING.txt")) {
-            into("META-INF/licenses")
-            rename { "winpthreads-COPYING.txt" }
-        }
-        filesMatching(listOf("plugin.yml", "paper-plugin.yml")) {
-            expand(
-                "version" to project.version,
-                "paperApiVersion" to paperApiVersion,
-                "mahjongUtilsVersion" to mahjongUtilsVersion,
-                "mariadbVersion" to mariadbVersion,
-                "h2Version" to h2Version,
-                "hikariVersion" to hikariVersion,
-                "kotlinRuntimeVersion" to kotlinRuntimeVersion,
-                "kotlinSerializationVersion" to kotlinSerializationVersion,
-            )
-        }
+    withType<Test>().configureEach {
+        jvmArgs("-javaagent:${mockitoAgent.singleFile.absolutePath}")
     }
 }
+
+MahjongBuildConfiguration.configureLifecycle(
+    project,
+    MahjongBuildInputs(
+        generatedResourcesDir,
+        generatedNativeResourcesDir,
+        codegenTasks + nativeTasks,
+        javaTargetVersion,
+        mapOf(
+            "version" to project.version,
+            "paperApiVersion" to paperApiVersion,
+            "mahjongUtilsVersion" to mahjongUtilsVersion,
+            "mariadbVersion" to mariadbVersion,
+            "h2Version" to h2Version,
+            "hikariVersion" to hikariVersion,
+            "kotlinRuntimeVersion" to kotlinRuntimeVersion,
+            "kotlinSerializationVersion" to kotlinSerializationVersion,
+        ),
+    ),
+)
 
 spotless {
     MahjongTaskRegistration.configureGitRatchet(project, "origin/dev") { ratchetFrom(it) }

--- a/buildSrc/src/main/kotlin/top/ellan/mahjong/build/MahjongBuildConfiguration.kt
+++ b/buildSrc/src/main/kotlin/top/ellan/mahjong/build/MahjongBuildConfiguration.kt
@@ -80,5 +80,4 @@ object MahjongBuildConfiguration {
             rename { targetName }
         }
     }
-
 }

--- a/buildSrc/src/main/kotlin/top/ellan/mahjong/build/MahjongBuildConfiguration.kt
+++ b/buildSrc/src/main/kotlin/top/ellan/mahjong/build/MahjongBuildConfiguration.kt
@@ -1,0 +1,84 @@
+package top.ellan.mahjong.build
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.language.jvm.tasks.ProcessResources
+import java.nio.charset.StandardCharsets
+
+data class MahjongBuildInputs(
+    val generatedResourcesDir: Provider<Directory>,
+    val generatedNativeResourcesDir: Provider<Directory>,
+    val generatedTaskDependencies: List<TaskProvider<out Task>>,
+    val javaTargetVersion: Int,
+    val resourceProperties: Map<String, Any>,
+)
+
+/** Build wiring extracted to keep the root script within its architecture budget. */
+object MahjongBuildConfiguration {
+    fun configureRepositories(project: Project) {
+        project.repositories.apply {
+            mavenCentral()
+            maven { setUrl("https://repo.papermc.io/repository/maven-public/") }
+            maven { setUrl("https://repo.codemc.io/repository/maven-releases/") }
+            maven { setUrl("https://repo.momirealms.net/releases/") }
+            maven { setUrl("https://jitpack.io") }
+        }
+    }
+
+    fun configureLifecycle(
+        project: Project,
+        inputs: MahjongBuildInputs,
+    ) {
+        project.tasks.withType(JavaCompile::class.java).configureEach {
+            options.encoding = StandardCharsets.UTF_8.name()
+            options.release.set(inputs.javaTargetVersion)
+            options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Werror"))
+        }
+        configureResources(project, inputs)
+    }
+
+    private fun configureResources(
+        project: Project,
+        inputs: MahjongBuildInputs,
+    ) {
+        project.tasks.named("processResources", ProcessResources::class.java).configure {
+            dependsOn(inputs.generatedTaskDependencies)
+            filteringCharset = StandardCharsets.UTF_8.name()
+            this.inputs.property("pluginVersion", inputs.resourceProperties.getValue("version").toString())
+            inputs.resourceProperties
+                .filterKeys { it != "version" }
+                .forEach(this.inputs::property)
+            from(inputs.generatedResourcesDir)
+            from(inputs.generatedNativeResourcesDir)
+            includeLicense("LICENSE", "LICENSE.txt", "META-INF")
+            from(project.rootProject.file("THIRD_PARTY_NOTICES.md")) {
+                into("META-INF")
+            }
+            from(project.rootProject.file("resourcepack/ATTRIBUTION.md")) {
+                into("META-INF")
+                rename { "RESOURCEPACK_ATTRIBUTION.md" }
+            }
+            includeLicense("native/gbmahjong/vendor/GB-Mahjong/LICENSE", "GB-Mahjong-LICENSE.txt")
+            includeLicense("native/gbmahjong/WINPTHREADS-COPYING.txt", "winpthreads-COPYING.txt")
+            filesMatching(listOf("plugin.yml", "paper-plugin.yml")) {
+                expand(inputs.resourceProperties)
+            }
+        }
+    }
+
+    private fun ProcessResources.includeLicense(
+        source: String,
+        targetName: String = source.substringAfterLast('/'),
+        targetDirectory: String = "META-INF/licenses",
+    ) {
+        from(project.rootProject.file(source)) {
+            into(targetDirectory)
+            rename { targetName }
+        }
+    }
+
+}

--- a/src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperLoader.java
+++ b/src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperLoader.java
@@ -16,12 +16,21 @@ public final class MahjongPaperLoader implements PluginLoader {
             "default",
             this.mavenCentralRepositoryUrl()
         ).build());
+        resolver.addRepository(new RemoteRepository.Builder(
+            "momirealms-releases",
+            "default",
+            "https://repo.momirealms.net/releases/"
+        ).build());
 
         this.addDependency(resolver, "io.github.ssttkkl:mahjong-utils-jvm:0.7.7");
         this.addDependency(resolver, "org.mariadb.jdbc:mariadb-java-client:3.5.9");
         this.addDependency(resolver, "com.mysql:mysql-connector-j:9.7.0");
         this.addDependency(resolver, "com.h2database:h2:2.4.240");
         this.addDependency(resolver, "com.zaxxer:HikariCP:7.1.0");
+        this.addDependency(resolver, "com.github.ben-manes.caffeine:caffeine:3.2.4");
+        this.addDependency(resolver, "net.momirealms:sparrow-heart:0.72");
+        this.addDependency(resolver, "net.momirealms:sparrow-reflection:0.33");
+        this.addDependency(resolver, "org.ow2.asm:asm:9.9.1");
         this.addDependency(resolver, "org.jetbrains.kotlin:kotlin-stdlib:2.4.0");
         this.addDependency(resolver, "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0");
 
@@ -44,4 +53,3 @@ public final class MahjongPaperLoader implements PluginLoader {
         return "https://repo.maven.apache.org/maven2/";
     }
 }
-

--- a/src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperPlugin.java
+++ b/src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperPlugin.java
@@ -27,12 +27,19 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandException;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.command.PluginIdentifiableCommand;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class MahjongPaperPlugin extends JavaPlugin {
@@ -50,6 +57,7 @@ public final class MahjongPaperPlugin extends JavaPlugin {
     private GameRoomSelectionService gameRoomSelectionService;
     private GameRoomSelectionPreviewService gameRoomSelectionPreviewService;
     private PluginTask gameRoomTickTask;
+    private Command commandMapFallback;
 
     @Override
     public void onEnable() {
@@ -133,6 +141,7 @@ public final class MahjongPaperPlugin extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        this.unregisterCommandMapFallback();
         if (this.craftEngine != null) {
             this.craftEngine.disableFurnitureInteractionBridge();
             this.craftEngine.clearTrackedCullables();
@@ -200,13 +209,37 @@ public final class MahjongPaperPlugin extends JavaPlugin {
 
         PluginCommand command = this.getCommand("mahjong");
         if (command == null) {
-            this.getLogger().severe("MahjongPaper command is missing from plugin.yml; disabling plugin.");
-            this.getServer().getPluginManager().disablePlugin(this);
-            return false;
+            return this.registerCommandMapFallback(mahjongCommand);
         }
         command.setExecutor(mahjongCommand);
         command.setTabCompleter(mahjongCommand);
         return true;
+    }
+
+    private boolean registerCommandMapFallback(MahjongCommand mahjongCommand) {
+        CommandMap commandMap = this.getServer().getCommandMap();
+        Command fallback = new CommandMapMahjongCommand(this, mahjongCommand);
+        this.commandMapFallback = fallback;
+        commandMap.register("mahjongpaper", fallback);
+        if (commandMap.getCommand("mahjong") == fallback || commandMap.getCommand("mahjongpaper:mahjong") == fallback) {
+            return true;
+        }
+
+        this.unregisterCommandMapFallback();
+        this.getLogger().severe("MahjongPaper command could not be registered through the server command map; disabling plugin.");
+        this.getServer().getPluginManager().disablePlugin(this);
+        return false;
+    }
+
+    private void unregisterCommandMapFallback() {
+        Command fallback = this.commandMapFallback;
+        if (fallback == null) {
+            return;
+        }
+        CommandMap commandMap = this.getServer().getCommandMap();
+        commandMap.getKnownCommands().entrySet().removeIf(entry -> entry.getValue() == fallback);
+        fallback.unregister(commandMap);
+        this.commandMapFallback = null;
     }
 
     private PaperCommandRegistrationResult registerPaperCommand(MahjongCommand mahjongCommand) {
@@ -235,9 +268,9 @@ public final class MahjongPaperPlugin extends JavaPlugin {
             );
             registerEventHandler.invoke(lifecycleManager, commandsEventType, handler);
             return PaperCommandRegistrationResult.REGISTERED;
-        } catch (ClassNotFoundException | NoSuchMethodException ex) {
+        } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException ex) {
             return PaperCommandRegistrationResult.UNAVAILABLE;
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchFieldException ex) {
+        } catch (IllegalAccessException | InvocationTargetException ex) {
             this.getLogger().log(Level.SEVERE, "Failed to register MahjongPaper command through Paper lifecycle events.", ex);
             return PaperCommandRegistrationResult.FAILED;
         }
@@ -293,6 +326,52 @@ public final class MahjongPaperPlugin extends JavaPlugin {
         REGISTERED,
         UNAVAILABLE,
         FAILED
+    }
+
+    private static final class CommandMapMahjongCommand extends Command implements PluginIdentifiableCommand {
+        private final MahjongPaperPlugin plugin;
+        private final MahjongCommand delegate;
+
+        private CommandMapMahjongCommand(MahjongPaperPlugin plugin, MahjongCommand delegate) {
+            super(
+                "mahjong",
+                "Manage MahjongPaper tables and rounds. Use /mahjong help for command explanations.",
+                "/mahjong <help|create|botmatch|mode|join|leave|list|spectate|unspectate|table|addbot|removebot|rule|start|state|riichi|tsumo|ron|pon|minkan|chii|kan|skip|kyuushu|settlement|rank|leaderboard|render|inspect|clear|forceend|deletetable|reload>",
+                List.of()
+            );
+            this.plugin = plugin;
+            this.delegate = delegate;
+            this.setPermission(delegate.permission());
+        }
+
+        @Override
+        public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+            if (!this.plugin.isEnabled()) {
+                throw new CommandException("Cannot execute /" + commandLabel + " because MahjongPaper is disabled.");
+            }
+            if (!this.testPermission(sender)) {
+                return true;
+            }
+            try {
+                return this.delegate.onCommand(sender, this, commandLabel, args);
+            } catch (Throwable throwable) {
+                throw new CommandException("Unhandled exception while executing /" + commandLabel + ".", throwable);
+            }
+        }
+
+        @Override
+        public List<String> tabComplete(CommandSender sender, String alias, String[] args) {
+            try {
+                return Objects.requireNonNullElse(this.delegate.onTabComplete(sender, this, alias, args), List.of());
+            } catch (Throwable throwable) {
+                throw new CommandException("Unhandled exception while tab-completing /" + alias + ".", throwable);
+            }
+        }
+
+        @Override
+        public Plugin getPlugin() {
+            return this.plugin;
+        }
     }
 
     public String reloadMahjongConfiguration() {

--- a/src/main/java/top/ellan/mahjong/gameroom/GameRoomWandListener.java
+++ b/src/main/java/top/ellan/mahjong/gameroom/GameRoomWandListener.java
@@ -1,6 +1,11 @@
 package top.ellan.mahjong.gameroom;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -11,7 +16,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
-import java.util.function.Supplier;
 import top.ellan.mahjong.config.PluginSettings;
 import top.ellan.mahjong.i18n.MessageService;
 
@@ -107,11 +111,13 @@ public final class GameRoomWandListener implements Listener {
             var persistentDataContainer = meta.getPersistentDataContainer();
             org.bukkit.NamespacedKey key = new org.bukkit.NamespacedKey("mahjongpaper", "wand");
             persistentDataContainer.set(key, org.bukkit.persistence.PersistentDataType.BYTE, (byte) 1);
-            meta.setDisplayName("§6§lMahjong Room Wand");
-            meta.setLore(java.util.List.of(
-                "§7Left-click: Set first corner",
-                "§7Right-click: Set second corner",
-                "§7Then use /mahjong room create <id>"
+            meta.displayName(
+                Component.text("Mahjong Room Wand", NamedTextColor.GOLD).decorate(TextDecoration.BOLD)
+            );
+            meta.lore(List.of(
+                Component.text("Left-click: Set first corner", NamedTextColor.GRAY),
+                Component.text("Right-click: Set second corner", NamedTextColor.GRAY),
+                Component.text("Then use /mahjong room create <id>", NamedTextColor.GRAY)
             ));
             wand.setItemMeta(meta);
         }

--- a/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
+++ b/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
@@ -575,7 +575,7 @@ public final class DisplayEntities {
         display.setLineWidth(160);
         display.setViewRange(LABEL_VIEW_RANGE);
         display.setBrightness(new Display.Brightness(15, 15));
-        display.setBackgroundColor(color);
+        TextDisplayBackgrounds.set(display, color);
         if (privateViewers != null && !privateViewers.isEmpty()) {
             DisplayVisibilityRegistry.registerPrivate(display.getEntityId(), privateViewers);
             syncPrivateVisibility(runtime, display, privateViewers);
@@ -747,7 +747,7 @@ public final class DisplayEntities {
         display.setLineWidth(160);
         display.setViewRange(LABEL_VIEW_RANGE);
         display.setBrightness(new Display.Brightness(15, 15));
-        display.setBackgroundColor(spec.color());
+        TextDisplayBackgrounds.set(display, spec.color());
         applyPrivateVisibility(runtime, display, spec.privateViewers(), true);
     }
 

--- a/src/main/java/top/ellan/mahjong/render/display/TextDisplayBackgrounds.java
+++ b/src/main/java/top/ellan/mahjong/render/display/TextDisplayBackgrounds.java
@@ -1,0 +1,44 @@
+package top.ellan.mahjong.render.display;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import org.bukkit.Color;
+import org.bukkit.entity.TextDisplay;
+
+/**
+ * Version-neutral access to the text-display background color.
+ *
+ * <p>Paper 1.20.1 temporarily marked this API as deprecated while retaining the exact same public
+ * signature that current Paper exposes without deprecation. A cached capability lookup keeps the
+ * minimum-version compiler from binding to that temporary annotation while preserving the exact
+ * ARGB behavior on every supported server.
+ */
+public final class TextDisplayBackgrounds {
+    private static final MethodHandle SET_BACKGROUND_COLOR = findSetter();
+
+    private TextDisplayBackgrounds() {
+    }
+
+    public static void set(TextDisplay display, Color color) {
+        try {
+            SET_BACKGROUND_COLOR.invokeExact(display, color);
+        } catch (RuntimeException | Error exception) {
+            throw exception;
+        } catch (Throwable throwable) {
+            throw new IllegalStateException("TextDisplay background-color invocation failed", throwable);
+        }
+    }
+
+    private static MethodHandle findSetter() {
+        try {
+            return MethodHandles.publicLookup().findVirtual(
+                TextDisplay.class,
+                "setBackgroundColor",
+                MethodType.methodType(void.class, Color.class)
+            );
+        } catch (NoSuchMethodException | IllegalAccessException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+}

--- a/src/main/java/top/ellan/mahjong/table/presentation/TableDiceAnimationCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/presentation/TableDiceAnimationCoordinator.java
@@ -1,6 +1,7 @@
 package top.ellan.mahjong.table.presentation;
 
 import top.ellan.mahjong.compat.PaperCompatibility;
+import top.ellan.mahjong.render.display.TextDisplayBackgrounds;
 import top.ellan.mahjong.runtime.PluginTask;
 import top.ellan.mahjong.table.core.TableSessionContext;
 import top.ellan.mahjong.riichi.model.OpeningDiceRoll;
@@ -181,7 +182,7 @@ public final class TableDiceAnimationCoordinator {
         spawned.setLineWidth(180);
         spawned.setViewRange(32.0F);
         spawned.setBrightness(new Display.Brightness(15, 15));
-        spawned.setBackgroundColor(RESULT_LABEL_BACKGROUND);
+        TextDisplayBackgrounds.set(spawned, RESULT_LABEL_BACKGROUND);
         return spawned;
     }
 


### PR DESCRIPTION
## Summary

- add a public `CommandMap` fallback for Paper 1.20.x while retaining lifecycle command registration on newer Paper
- resolve Caffeine, Sparrow Heart 0.72, Sparrow Reflection 0.33, and ASM 9.9.1 through Paper's plugin loader
- raise the minimum runtime bytecode to Java 21 because Sparrow Heart 0.72 is Java 21
- keep Sparrow Reflection/Unsafe/ASM capabilities available; this PR does not remove or replace them
- replace direct source bindings to temporarily deprecated 1.20.1 APIs and fail future Java deprecation warnings with `-Werror`
- add checksum-locked GitHub standard `server.jar` cold-start jobs for Paper 1.20.1, 1.20.4, 1.21.1, and 26.1.2
- use the latest CraftEngine Community 26.7.3 Paper/Folia/Purpur artifact (`Len451or`), not the same-version Bukkit/Spigot artifact that only supports Minecraft 26.x

## Scope

This is compatibility/foundation work, not a performance claim. Pure performance changes remain in separate PRs and must pass paired A/B gates before merge recommendation.

## GitHub validation

Actions are the authoritative validator for this PR. The compatibility matrix downloads immutable Paper objects and the Modrinth-published CraftEngine Paper artifact, verifies checksums, cold-starts each standard Paper jar, executes `/mahjong help`, verifies exact loader dependency hashes, and requires a clean stop.

Build run [29468341078](https://github.com/EllanServer/MahjongEngine/actions/runs/29468341078) proved that the exact checksum-locked `Len451or` artifact behaves as follows:

| Standard Paper | Latest CraftEngine 26.7.3 result |
| --- | --- |
| 1.20.1-196 | fails inside CraftEngine proxy binding: `ClientboundSetCursorItemPacketProxy` has no proxied class; CraftEngine requests shutdown |
| 1.20.4-499 | same upstream CraftEngine proxy-binding failure |
| 1.21.1-133 | same upstream CraftEngine proxy-binding failure |
| 26.1.2-74 | CraftEngine fully enables; the previous job failure was only an overly strict command-output assertion |

The workflow now reports CraftEngine initialization failures directly and accepts MahjongPaper's intentional player-only response to the console command. It deliberately does not hide declared-version regressions by substituting an older CraftEngine build.