### PR TITLE
perf(render): compute viewer exclusions only for occupied seats

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRenderSnapshotFactory.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRenderSnapshotFactory.java
@@ -5,10 +5,8 @@ import top.ellan.mahjong.render.TableRenderSubject;
 import top.ellan.mahjong.render.snapshot.TableRenderSnapshot;
 import top.ellan.mahjong.render.snapshot.TableSeatRenderSnapshot;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -26,15 +24,9 @@ public final class TableRenderSnapshotFactory {
             .sorted(Comparator.comparing(UUID::toString))
             .toList();
         Set<UUID> onlineViewerIdSet = new HashSet<>(onlineViewerIds);
-        Map<UUID, String> viewerMembershipSignatures = new HashMap<>();
-        Map<UUID, List<UUID>> viewerIdsExcluding = new HashMap<>();
-        for (UUID viewerId : onlineViewerIds) {
-            viewerMembershipSignatures.put(viewerId, this.viewerMembershipSignature(onlineViewerIds, viewerId));
-            viewerIdsExcluding.put(viewerId, this.viewerIdsExcluding(onlineViewerIds, viewerId));
-        }
         EnumMap<SeatWind, TableSeatRenderSnapshot> seats = new EnumMap<>(SeatWind.class);
         for (SeatWind wind : SeatWind.values()) {
-            seats.put(wind, this.captureSeatSnapshot(session, wind, onlineViewerIdSet, viewerMembershipSignatures, viewerIdsExcluding));
+            seats.put(wind, this.captureSeatSnapshot(session, wind, onlineViewerIds, onlineViewerIdSet));
         }
         return new TableRenderSnapshot(
             version,
@@ -100,12 +92,18 @@ public final class TableRenderSnapshotFactory {
     private TableSeatRenderSnapshot captureSeatSnapshot(
         TableRenderSubject session,
         SeatWind wind,
-        Set<UUID> onlineViewerIdSet,
-        Map<UUID, String> viewerMembershipSignatures,
-        Map<UUID, List<UUID>> viewerIdsExcluding
+        List<UUID> onlineViewerIds,
+        Set<UUID> onlineViewerIdSet
     ) {
         UUID playerId = session.playerAt(wind);
         boolean occupied = playerId != null;
+        boolean online = occupied && onlineViewerIdSet.contains(playerId);
+        String viewerMembershipSignature = online
+            ? this.viewerMembershipSignature(onlineViewerIds, playerId)
+            : "";
+        List<UUID> viewerIdsExcluding = online
+            ? this.viewerIdsExcluding(onlineViewerIds, playerId)
+            : List.of();
         return new TableSeatRenderSnapshot(
             wind,
             playerId,
@@ -115,13 +113,13 @@ public final class TableRenderSnapshotFactory {
             occupied && session.isRiichi(playerId),
             occupied && session.isReady(playerId),
             occupied && session.isQueuedToLeave(playerId),
-            occupied && onlineViewerIdSet.contains(playerId),
-            occupied ? viewerMembershipSignatures.getOrDefault(playerId, "") : "",
+            online,
+            viewerMembershipSignature,
             occupied ? session.selectedHandTileIndex(playerId) : -1,
             occupied ? session.selectedHandTileIndices(playerId) : List.of(),
             occupied ? session.riichiDiscardIndex(playerId) : -1,
             session.stickLayoutCount(wind),
-            occupied ? viewerIdsExcluding.getOrDefault(playerId, List.of()) : List.of(),
+            viewerIdsExcluding,
             occupied ? session.hand(playerId) : List.of(),
             occupied ? session.discards(playerId) : List.of(),
             occupied ? session.fuuro(playerId) : List.of(),

--- a/src/test/kotlin/top/ellan/mahjong/table/render/TableRenderSnapshotFactoryTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/render/TableRenderSnapshotFactoryTest.kt
@@ -18,12 +18,13 @@ import kotlin.test.assertTrue
 
 class TableRenderSnapshotFactoryTest {
     @Test
-    fun `render snapshot reuses precomputed online viewers`() {
+    fun `render snapshot derives exclusions only for online seats`() {
         val session = mock(MahjongTableSession::class.java)
         val factory = TableRenderSnapshotFactory()
 
         val eastId = UUID.fromString("00000000-0000-0000-0000-000000000011")
         val southId = UUID.fromString("00000000-0000-0000-0000-000000000012")
+        val westId = UUID.fromString("00000000-0000-0000-0000-000000000013")
         val eastViewer = mock(Player::class.java)
         val southViewer = mock(Player::class.java)
 
@@ -49,7 +50,7 @@ class TableRenderSnapshotFactoryTest {
         `when`(session.doraIndicators()).thenReturn(emptyList())
         `when`(session.playerAt(SeatWind.EAST)).thenReturn(eastId)
         `when`(session.playerAt(SeatWind.SOUTH)).thenReturn(southId)
-        `when`(session.playerAt(SeatWind.WEST)).thenReturn(null)
+        `when`(session.playerAt(SeatWind.WEST)).thenReturn(westId)
         `when`(session.playerAt(SeatWind.NORTH)).thenReturn(null)
 
         doAnswer { invocation ->
@@ -61,7 +62,7 @@ class TableRenderSnapshotFactoryTest {
             `when`(session.stickLayoutCount(wind)).thenReturn(0)
             `when`(session.cornerSticks(wind)).thenReturn(emptyList())
         }
-        for (playerId in listOf(eastId, southId)) {
+        for (playerId in listOf(eastId, southId, westId)) {
             `when`(session.points(playerId)).thenReturn(25000)
             `when`(session.isRiichi(playerId)).thenReturn(false)
             `when`(session.isReady(playerId)).thenReturn(false)
@@ -77,6 +78,7 @@ class TableRenderSnapshotFactoryTest {
         val snapshot = factory.create(session, 1L, 0L)
         val eastSeat = snapshot.seat(SeatWind.EAST)
         val southSeat = snapshot.seat(SeatWind.SOUTH)
+        val westSeat = snapshot.seat(SeatWind.WEST)
 
         assertTrue(eastSeat.online())
         assertTrue(southSeat.online())
@@ -84,6 +86,9 @@ class TableRenderSnapshotFactoryTest {
         assertEquals(listOf(eastId), southSeat.viewerIdsExcluding())
         assertEquals(southId.toString(), eastSeat.viewerMembershipSignature())
         assertEquals(eastId.toString(), southSeat.viewerMembershipSignature())
+        assertTrue(!westSeat.online())
+        assertTrue(westSeat.viewerIdsExcluding().isEmpty())
+        assertTrue(westSeat.viewerMembershipSignature().isEmpty())
 
         verify(session, never()).onlinePlayer(ArgumentMatchers.any(UUID::class.java))
         verify(session, never()).viewerIdsExcluding(ArgumentMatchers.any(UUID::class.java))

--- a/src/test/kotlin/top/ellan/mahjong/table/render/TableRenderSnapshotFactoryTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/render/TableRenderSnapshotFactoryTest.kt
@@ -1,8 +1,5 @@
 package top.ellan.mahjong.table.render
 
-import top.ellan.mahjong.model.SeatWind
-import top.ellan.mahjong.render.scene.MeldView
-import top.ellan.mahjong.table.core.MahjongTableSession
 import org.bukkit.Location
 import org.bukkit.entity.Player
 import org.mockito.ArgumentMatchers
@@ -11,6 +8,9 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import top.ellan.mahjong.model.SeatWind
+import top.ellan.mahjong.render.scene.MeldView
+import top.ellan.mahjong.table.core.MahjongTableSession
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -131,4 +131,3 @@ class TableRenderSnapshotFactoryTest {
         verify(session, never()).doraIndicators()
     }
 }
-


### PR DESCRIPTION
## Pure performance scope

This PR changes only the render-snapshot viewer exclusion precomputation and its behavior-preservation test. It does not change game rules, render ordering, visibility policy, packets, timers, interaction handling, or supported platforms.

## Candidate

Before this change, every render snapshot built an exclusion UUID list and membership signature for every online viewer, although the snapshot only consumes those values for the four occupied seats.

The candidate computes the same sorted/distinct viewer-derived values only for occupied seats that are actually online:

- before: approximately O(V²) UUID/string work and O(V) exclusion collections
- candidate: O(S × V), where S is at most four
- offline occupied seats retain the exact existing empty signature/list behavior
- UUID sort order, duplicate removal, and resulting snapshot values are unchanged

## Evidence gate

No performance claim is made from source inspection. GitHub is the authoritative validator.

Required before merge recommendation:

- Build and unit-test Actions pass
- trusted `snapshot` profile completes A/A drift control
- eight paired A/B measurements pass the configured time and allocation gates
- standard server.jar evidence shows no TPS/MSPT or packet regression

The existing protected benchmark covers the real production `TableRenderSnapshotFactory` at 4, 32, and 128 viewers. This PR must not alter that benchmark or its thresholds.