### PR TITLE
perf(gb): allocate discard hands only on ting cache miss

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -189,9 +189,15 @@ final class GbBotDecisionService {
         EnumMap<MahjongTile, GbTingResponse> tingMemo = new EnumMap<>(MahjongTile.class);
         for (int i = 0; i < hand.size(); i++) {
             MahjongTile discarded = hand.get(i);
-            List<MahjongTile> remaining = new ArrayList<>(hand);
-            remaining.remove(i);
-            GbTingResponse ting = tingMemo.computeIfAbsent(discarded, ignored -> tingEvaluator.evaluate(remaining, melds));
+            GbTingResponse ting = tingMemo.get(discarded);
+            if (ting == null) {
+                List<MahjongTile> remaining = new ArrayList<>(hand);
+                remaining.remove(i);
+                ting = tingEvaluator.evaluate(remaining, melds);
+                if (ting != null) {
+                    tingMemo.put(discarded, ting);
+                }
+            }
             DiscardChoice candidate = new DiscardChoice(i, readyScore(ting), discardPreference(hand, discarded));
             if (best == null || candidate.compareTo(best) > 0) {
                 best = candidate;

--- a/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
@@ -43,4 +43,38 @@ class GbBotDecisionServiceTest {
 
         assertEquals(3, suggestedIndex)
     }
+
+    @Test
+    fun `discard suggestion evaluates the first remaining hand once per duplicated tile`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M1, MahjongTile.M2, MahjongTile.M1)
+        val evaluatedHands = mutableListOf<List<MahjongTile>>()
+
+        service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
+            evaluatedHands += remaining.toList()
+            GbTingResponse(true, emptyList(), null)
+        }
+
+        assertEquals(
+            listOf(
+                listOf(MahjongTile.M2, MahjongTile.M1),
+                listOf(MahjongTile.M1, MahjongTile.M1),
+            ),
+            evaluatedHands,
+        )
+    }
+
+    @Test
+    fun `discard suggestion preserves null evaluator recomputation`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M1, MahjongTile.M1, MahjongTile.M1)
+        var evaluations = 0
+
+        service.suggestedDiscardIndex(hand, emptyList()) { _, _ ->
+            evaluations++
+            null
+        }
+
+        assertEquals(hand.size, evaluations)
+    }
 }

--- a/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
@@ -24,7 +24,7 @@ class GbBotDecisionServiceTest {
 
         assertTrue(
             GbBotDecisionService.discardPreference(hand, MahjongTile.P9) >
-                GbBotDecisionService.discardPreference(hand, MahjongTile.M2)
+                GbBotDecisionService.discardPreference(hand, MahjongTile.M2),
         )
     }
 
@@ -33,13 +33,14 @@ class GbBotDecisionServiceTest {
         val service = GbBotDecisionService(8)
         val hand = listOf(MahjongTile.M1, MahjongTile.M2, MahjongTile.M3, MahjongTile.EAST)
 
-        val suggestedIndex = service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
-            if (MahjongTile.EAST !in remaining) {
-                GbTingResponse(true, listOf(GbTingCandidate("W1", 8)), null)
-            } else {
-                GbTingResponse(true, emptyList(), null)
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
+                if (MahjongTile.EAST !in remaining) {
+                    GbTingResponse(true, listOf(GbTingCandidate("W1", 8)), null)
+                } else {
+                    GbTingResponse(true, emptyList(), null)
+                }
             }
-        }
 
         assertEquals(3, suggestedIndex)
     }


### PR DESCRIPTION
## Pure performance scope

This PR changes only the GB bot discard evaluator's existing per-tile memo lookup and adds behavior-preservation tests. It does not change scoring, reaction priority, discard ranking, evaluator call order, or bot timing.

## Candidate

The baseline memoizes non-null ting results by discarded tile, but allocates and mutates a complete remaining-hand copy before checking that memo. Repeated tiles therefore allocate throwaway lists even though their evaluator result is already cached.

The candidate performs the same lookup first and builds the remaining hand only on a cache miss:

- the first occurrence of each tile still determines the evaluated remaining-hand order
- non-null results are still evaluated once per distinct tile
- null results are still not cached and are recomputed for every occurrence
- every discard index is still ranked independently with the same result and preference

## Evidence gate

No performance claim is made from source inspection. GitHub is the authoritative validator.

Required before merge recommendation:

- Build and unit-test Actions pass
- trusted `gb-bot` profile completes A/A drift control
- eight paired A/B measurements pass the configured time and allocation gates
- duplicate and mixed hands improve without a protected unique-hand regression
- standard server.jar evidence shows no TPS/MSPT or packet regression

The protected benchmark already asserts evaluator counts and measures the real production path for duplicate, mixed, and unique hands. This PR does not modify that benchmark or its thresholds.