### PR TITLE
perf(core): avoid primitive fingerprint boxing

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/DelimitedFingerprintBuilder.java
+++ b/src/main/java/top/ellan/mahjong/table/core/DelimitedFingerprintBuilder.java
@@ -15,12 +15,27 @@ public final class DelimitedFingerprintBuilder {
     }
 
     public DelimitedFingerprintBuilder field(Object value) {
-        if (this.needsSeparator) {
-            this.delegate.append(':');
-        }
+        this.appendFieldSeparator();
         this.delegate.append(Objects.toString(value, ""));
-        this.needsSeparator = true;
-        return this;
+        return this.finishField();
+    }
+
+    public DelimitedFingerprintBuilder field(boolean value) {
+        this.appendFieldSeparator();
+        this.delegate.append(value);
+        return this.finishField();
+    }
+
+    public DelimitedFingerprintBuilder field(char value) {
+        this.appendFieldSeparator();
+        this.delegate.append(value);
+        return this.finishField();
+    }
+
+    public DelimitedFingerprintBuilder field(int value) {
+        this.appendFieldSeparator();
+        this.delegate.append(value);
+        return this.finishField();
     }
 
     public DelimitedFingerprintBuilder raw(Object value) {
@@ -31,6 +46,17 @@ public final class DelimitedFingerprintBuilder {
     public DelimitedFingerprintBuilder entrySeparator() {
         this.delegate.append(';');
         this.needsSeparator = false;
+        return this;
+    }
+
+    private void appendFieldSeparator() {
+        if (this.needsSeparator) {
+            this.delegate.append(':');
+        }
+    }
+
+    private DelimitedFingerprintBuilder finishField() {
+        this.needsSeparator = true;
         return this;
     }
 

--- a/src/test/java/top/ellan/mahjong/table/core/DelimitedFingerprintBuilderTest.java
+++ b/src/test/java/top/ellan/mahjong/table/core/DelimitedFingerprintBuilderTest.java
@@ -1,0 +1,38 @@
+package top.ellan.mahjong.table.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DelimitedFingerprintBuilderTest {
+    @Test
+    void optimizedPrimitiveFieldsPreserveDelimitedTextAndObjectFallbacks() {
+        String fingerprint = DelimitedFingerprintBuilder.create(128)
+            .field((byte) -128)
+            .field((short) -32768)
+            .field(Integer.MIN_VALUE)
+            .field(Long.MIN_VALUE)
+            .field(1.25F)
+            .field(-0.0D)
+            .field('Z')
+            .field(true)
+            .field(false)
+            .field((Object) null)
+            .toString();
+
+        assertEquals("-128:-32768:-2147483648:-9223372036854775808:1.25:-0.0:Z:true:false:", fingerprint);
+    }
+
+    @Test
+    void primitiveFieldsKeepRawAndEntrySeparatorSemantics() {
+        String fingerprint = DelimitedFingerprintBuilder.create(32)
+            .field(1)
+            .entrySeparator()
+            .field(false)
+            .raw("|")
+            .field((Object) null)
+            .toString();
+
+        assertEquals("1;false|:", fingerprint);
+    }
+}


### PR DESCRIPTION
## What changed

- add exact-output `boolean`, `char`, and `int` overloads to `DelimitedFingerprintBuilder.field`
- keep the existing object/null, delimiter, raw, and entry-separator semantics unchanged
- add focused regression coverage for primitive text encoding and fallback behavior

## Why

Hot render/HUD signature paths currently route primitive values through `field(Object)`, which boxes them and materializes an intermediate string before appending. The primitive overloads append directly to the existing `StringBuilder`. The `char` overload is required so Java widening to `int` cannot change character output.

## Validation

No Gradle, JMH, test, or server workload was run locally, per project policy. GitHub Build/Test is the functional gate. This PR stays draft and must not merge until the base-owned A/B lock fix (#60) lands and the protected fingerprint profile reports `PASS_OPTIMIZED`; a separate base-owned harness change will also enforce exact JMH output and allocation evidence.