### PR TITLE
perf(render): encode primitive fingerprints without strings

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -264,19 +264,81 @@ public final class TableRegionFingerprintService {
         private boolean needsSeparator;
 
         private FingerprintBuilder field(Object value) {
-            if (this.needsSeparator) {
-                this.mix(':');
-            }
-            String text = Objects.toString(value, "");
-            for (int index = 0; index < text.length(); index++) {
-                this.mix(text.charAt(index));
-            }
-            this.needsSeparator = true;
-            return this;
+            this.startField();
+            this.mixText(Objects.toString(value, ""));
+            return this.finishField();
+        }
+
+        private FingerprintBuilder field(boolean value) {
+            this.startField();
+            this.mixText(value ? "true" : "false");
+            return this.finishField();
+        }
+
+        private FingerprintBuilder field(char value) {
+            this.startField();
+            this.mix(value);
+            return this.finishField();
+        }
+
+        private FingerprintBuilder field(int value) {
+            this.startField();
+            this.mixDecimal(value);
+            return this.finishField();
+        }
+
+        private FingerprintBuilder field(long value) {
+            this.startField();
+            this.mixDecimal(value);
+            return this.finishField();
         }
 
         private long value() {
             return this.hash;
+        }
+
+        private void startField() {
+            if (this.needsSeparator) {
+                this.mix(':');
+            }
+        }
+
+        private FingerprintBuilder finishField() {
+            this.needsSeparator = true;
+            return this;
+        }
+
+        private void mixText(String value) {
+            for (int index = 0; index < value.length(); index++) {
+                this.mix(value.charAt(index));
+            }
+        }
+
+        private void mixDecimal(long value) {
+            long remaining = value > 0L ? -value : value;
+            long lowDigits = 0L;
+            long highDigits = 0L;
+            int digitCount = 0;
+            do {
+                int digit = (int) -(remaining % 10L);
+                if (digitCount < 16) {
+                    lowDigits |= (long) digit << (digitCount * 4);
+                } else {
+                    highDigits |= (long) digit << ((digitCount - 16) * 4);
+                }
+                digitCount++;
+                remaining /= 10L;
+            } while (remaining != 0L);
+
+            if (value < 0L) {
+                this.mix('-');
+            }
+            for (int index = digitCount - 1; index >= 0; index--) {
+                int digit = index < 16
+                    ? (int) (lowDigits >>> (index * 4)) & 0x0f
+                    : (int) (highDigits >>> ((index - 16) * 4)) & 0x0f;
+                this.mix((char) ('0' + digit));
+            }
         }
 
         private void mix(char value) {

--- a/src/test/java/top/ellan/mahjong/table/render/TableRegionFingerprintServiceTest.java
+++ b/src/test/java/top/ellan/mahjong/table/render/TableRegionFingerprintServiceTest.java
@@ -1,0 +1,81 @@
+package top.ellan.mahjong.table.render;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TableRegionFingerprintServiceTest {
+    @Test
+    void primitiveFieldsPreserveTheDelimitedTextFingerprint() throws ReflectiveOperationException {
+        Class<?> builderType = Class.forName(TableRegionFingerprintService.class.getName() + "$FingerprintBuilder");
+        Constructor<?> constructor = builderType.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Object builder = constructor.newInstance();
+
+        Method objectField = accessible(builderType.getDeclaredMethod("field", Object.class));
+        Method booleanField = accessible(builderType.getDeclaredMethod("field", boolean.class));
+        Method charField = accessible(builderType.getDeclaredMethod("field", char.class));
+        Method intField = accessible(builderType.getDeclaredMethod("field", int.class));
+        Method longField = accessible(builderType.getDeclaredMethod("field", long.class));
+        Method value = accessible(builderType.getDeclaredMethod("value"));
+
+        objectField.invoke(builder, "prefix");
+        booleanField.invoke(builder, true);
+        booleanField.invoke(builder, false);
+        charField.invoke(builder, 'Z');
+        intField.invoke(builder, 0);
+        intField.invoke(builder, 1);
+        intField.invoke(builder, -1);
+        intField.invoke(builder, Integer.MIN_VALUE);
+        intField.invoke(builder, Integer.MAX_VALUE);
+        longField.invoke(builder, Long.MIN_VALUE);
+        longField.invoke(builder, Long.MAX_VALUE);
+        objectField.invoke(builder, new Object[] {null});
+
+        assertEquals(
+            referenceFingerprint(
+                "prefix",
+                true,
+                false,
+                'Z',
+                0,
+                1,
+                -1,
+                Integer.MIN_VALUE,
+                Integer.MAX_VALUE,
+                Long.MIN_VALUE,
+                Long.MAX_VALUE,
+                null
+            ),
+            value.invoke(builder)
+        );
+    }
+
+    private static Method accessible(Method method) {
+        method.setAccessible(true);
+        return method;
+    }
+
+    private static long referenceFingerprint(Object... fields) {
+        long hash = 0xcbf29ce484222325L;
+        boolean needsSeparator = false;
+        for (Object field : fields) {
+            if (needsSeparator) {
+                hash = mix(hash, ':');
+            }
+            String text = Objects.toString(field, "");
+            for (int index = 0; index < text.length(); index++) {
+                hash = mix(hash, text.charAt(index));
+            }
+            needsSeparator = true;
+        }
+        return hash;
+    }
+
+    private static long mix(long hash, char value) {
+        return (hash ^ value) * 0x100000001b3L;
+    }
+}


### PR DESCRIPTION
## What changed

- specialize the private region fingerprint builder for `boolean`, `char`, `int`, and `long`
- encode signed decimal digits directly into the existing FNV stream without boxing, temporary numeric strings, or arrays
- preserve the existing `:` separators and exact `Objects.toString(value, "")` character contract, including zero and all MIN/MAX boundaries
- add a focused independent-reference regression test for the complete primitive sequence

## Why

A full table render computes hundreds of region/tile fingerprints. Primitive fields currently box and materialize temporary decimal strings before each per-character FNV pass. The new encoder packs reverse decimal digits into two local longs, then emits them in the original order; it handles `Long.MIN_VALUE` in the negative domain to avoid overflow.

This deliberately does **not** use the behavior-changing type-marker/binary encoding from the dirty development tree.

## Validation

No Gradle, JMH, test, or server workload was run locally. GitHub Build/Test is the functional gate. This PR remains draft and must not merge until #60 and the base-owned region profile in #62 land, then #62's independent exact-FNV oracle and time/allocation A/B must report `PASS_OPTIMIZED`.