### PR TITLE
perf(render): specialize singleton display spawns

### DIFF
--- a/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
+++ b/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
@@ -126,6 +126,10 @@ public final class DisplayEntities {
             return List.of();
         }
         DisplayEntityRuntime scopedRuntime = visibilitySnapshotRuntime(runtime);
+        if (specs.size() == 1) {
+            Entity entity = specs.get(0).spawn(scopedRuntime);
+            return entity == null ? List.of() : List.of(entity);
+        }
         List<Entity> spawned = new java.util.ArrayList<>(specs.size());
         for (EntitySpec spec : specs) {
             Entity entity = spec.spawn(scopedRuntime);


### PR DESCRIPTION
## Summary

- specialize `DisplayEntities.spawnAll` when a region contains exactly one spec
- preserve the existing visibility snapshot, spec spawn call, null filtering, entity identity, and immutable-list contract
- avoid the intermediate capacity-one `ArrayList` and subsequent copy for the 268 singleton regions in the representative table profile

## Scope

Production candidate only: four added lines in `DisplayEntities.java`. No benchmark, threshold, workflow, dependency, or configuration changes.

## Validation

All functional checks and benchmarking run only on GitHub. After Build/Test are green, this candidate will run the merged base-owned `display-spawn` paired A/B profile and may merge only if the final decision is `PASS_OPTIMIZED`.