### PR TITLE
perf(gb): reuse adjacent discard preference on memo hit

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -187,9 +187,12 @@ final class GbBotDecisionService {
         }
         DiscardChoice best = null;
         EnumMap<MahjongTile, GbTingResponse> tingMemo = new EnumMap<>(MahjongTile.class);
+        MahjongTile previousDiscarded = null;
+        int previousDiscardPreference = 0;
         for (int i = 0; i < hand.size(); i++) {
             MahjongTile discarded = hand.get(i);
             GbTingResponse ting = tingMemo.get(discarded);
+            boolean tingMemoHit = ting != null;
             if (ting == null) {
                 List<MahjongTile> remaining = new ArrayList<>(hand);
                 remaining.remove(i);
@@ -198,7 +201,13 @@ final class GbBotDecisionService {
                     tingMemo.put(discarded, ting);
                 }
             }
-            DiscardChoice candidate = new DiscardChoice(i, readyScore(ting), discardPreference(hand, discarded));
+            long candidateReadyScore = readyScore(ting);
+            int candidateDiscardPreference = tingMemoHit && discarded == previousDiscarded
+                ? previousDiscardPreference
+                : discardPreference(hand, discarded);
+            DiscardChoice candidate = new DiscardChoice(i, candidateReadyScore, candidateDiscardPreference);
+            previousDiscarded = discarded;
+            previousDiscardPreference = candidateDiscardPreference;
             if (best == null || candidate.compareTo(best) > 0) {
                 best = candidate;
             }

--- a/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
@@ -66,6 +66,56 @@ class GbBotDecisionServiceTest {
     }
 
     @Test
+    fun `discard suggestion keeps the earliest index for equal duplicate candidates`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M1, MahjongTile.M1, MahjongTile.M1)
+        var evaluations = 0
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { _, _ ->
+                evaluations++
+                GbTingResponse(true, emptyList(), null)
+            }
+
+        assertEquals(0, suggestedIndex)
+        assertEquals(1, evaluations)
+    }
+
+    @Test
+    fun `discard suggestion recomputes null before memoizing a later duplicate response`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M1, MahjongTile.M1, MahjongTile.M1)
+        val ready = GbTingResponse(true, listOf(GbTingCandidate("W1", 8)), null)
+        var evaluations = 0
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { _, _ ->
+                evaluations++
+                if (evaluations == 1) null else ready
+            }
+
+        assertEquals(1, suggestedIndex)
+        assertEquals(2, evaluations)
+    }
+
+    @Test
+    fun `discard suggestion does not reuse red five preference for the exact regular tile`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M5, MahjongTile.M5_RED, MahjongTile.M5)
+        val ready = GbTingResponse(true, listOf(GbTingCandidate("W1", 8)), null)
+        var evaluations = 0
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
+                evaluations++
+                if (MahjongTile.M5_RED in remaining) ready else GbTingResponse(true, emptyList(), null)
+            }
+
+        assertEquals(0, suggestedIndex)
+        assertEquals(2, evaluations)
+    }
+
+    @Test
     fun `discard suggestion preserves null evaluator recomputation`() {
         val service = GbBotDecisionService(8)
         val hand = listOf(MahjongTile.M1, MahjongTile.M1, MahjongTile.M1)


### PR DESCRIPTION
## Pure performance scope

This PR changes only the GB bot discard preference lookup inside the existing per-index decision loop and adds focused behavior-preservation tests. It does not change the protected benchmark, thresholds, Gradle configuration, bot timing, scoring, evaluator order, or discard tie-breaking.

## Candidate

After the previous ting memo optimization, an adjacent duplicate tile can reuse the same non-null ting response while still rescanning the entire hand for the same discard preference.

The candidate reuses only the immediately preceding preference when all of these invariants hold:

- the current index entered with a non-null exact-tile ting memo hit
- the current tile is the same exact `MahjongTile` enum constant as the previous index
- `readyScore` is still evaluated before the preference, preserving argument evaluation order
- every index still constructs and compares its own `DiscardChoice`

Null evaluator responses remain uncached and recompute at every index. `M5` and `M5_RED` remain distinct; no `sameKind` comparison is used. Equal candidates still retain the earliest index.

## Behavior coverage

Focused tests cover:

- `[M1, M1, M1]` retaining the earliest index
- a null response followed by READY on repeated tiles, including the later memo hit
- `[M5, M5_RED, M5]` preventing red-five preference reuse for the exact regular tile
- the existing null-recomputation and first-remaining-hand invariants

## Evidence gate

No performance claim is made from source inspection or local execution. GitHub is the authoritative validator.

Required before merge recommendation:

- Build and unit-test Actions pass
- trusted `gb-bot` A/A drift control passes
- eight paired AB/BA measurements complete
- at least two primary metrics pass, including the duplicate-hand must-pass metric
- all allocation and unique-hand guardrails hold

If the trusted decision is not `PASS_OPTIMIZED`, this candidate will not be merged.