### PR TITLE
fix(perf): validate profile primary thresholds

### DIFF
--- a/perf/ab/gate-config.json
+++ b/perf/ab/gate-config.json
@@ -116,7 +116,7 @@
         "display.spawn.time",
         "display.spawn.alloc"
       ],
-      "minimum_passes": 2,
+      "minimum_passes": 1,
       "must_pass": [
         "display.spawn.time"
       ],
@@ -130,7 +130,7 @@
         "region.queue.time",
         "region.queue.alloc"
       ],
-      "minimum_passes": 2,
+      "minimum_passes": 1,
       "must_pass": [
         "region.queue.time"
       ],

--- a/perf/ab/gate.py
+++ b/perf/ab/gate.py
@@ -451,6 +451,29 @@ def render_markdown(decision: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def validate_profile_config(
+    config: dict[str, Any],
+    profile_name: str,
+    benchmark_specs: list[dict[str, Any]],
+) -> tuple[set[str], int]:
+    profile = config["profiles"][profile_name]
+    configured_ids = [entry["id"] for entry in benchmark_specs]
+    if len(configured_ids) != len(set(configured_ids)):
+        raise ValueError(f"profile {profile_name} contains duplicate benchmark ids")
+    primary_ids = {
+        entry["id"] for entry in benchmark_specs if entry.get("metric", "primary") == "primary"
+    }
+    must_pass = set(profile.get("must_pass", []))
+    if not must_pass or not must_pass.issubset(primary_ids):
+        raise ValueError(f"profile {profile_name} must_pass must contain only primary metrics")
+    minimum_passes = profile.get("minimum_passes")
+    if isinstance(minimum_passes, bool) or not isinstance(minimum_passes, int):
+        raise ValueError(f"profile {profile_name} has a non-integer primary minimum_passes")
+    if not 1 <= minimum_passes <= len(primary_ids):
+        raise ValueError(f"profile {profile_name} has an invalid primary minimum_passes")
+    return must_pass, minimum_passes
+
+
 def evaluate(
     config: dict[str, Any],
     profile_name: str,
@@ -465,19 +488,7 @@ def evaluate(
     aa_passed = True
     reasons: list[str] = []
 
-    profile = config["profiles"][profile_name]
-    must_pass = set(profile.get("must_pass", []))
-    configured_ids = [entry["id"] for entry in benchmark_specs]
-    if len(configured_ids) != len(set(configured_ids)):
-        raise ValueError(f"profile {profile_name} contains duplicate benchmark ids")
-    primary_ids = {
-        entry["id"] for entry in benchmark_specs if entry.get("metric", "primary") == "primary"
-    }
-    if not must_pass or not must_pass.issubset(primary_ids):
-        raise ValueError(f"profile {profile_name} must_pass must contain only primary metrics")
-    minimum_passes = int(profile["minimum_passes"])
-    if not 1 <= minimum_passes <= len(primary_ids):
-        raise ValueError(f"profile {profile_name} has an invalid primary minimum_passes")
+    must_pass, minimum_passes = validate_profile_config(config, profile_name, benchmark_specs)
     for entry in benchmark_specs:
         benchmark_id = entry["id"]
         aa_metrics = paired_statistics(
@@ -583,6 +594,7 @@ def run(args: argparse.Namespace) -> int:
     benchmark_specs = [benchmark_index[benchmark_id] for benchmark_id in profile["benchmark_ids"]]
     if not benchmark_specs:
         raise ValueError("at least one benchmark metric must be configured")
+    validate_profile_config(config, args.profile, benchmark_specs)
     config_sha = sha256_file(config_path)
     repetitions = int(config["matrix"]["repetitions_per_order"])
     aa_pairs, aa_units, aa_run = load_pairs(

--- a/perf/ab/tests/test_gate.py
+++ b/perf/ab/tests/test_gate.py
@@ -272,6 +272,25 @@ class GateTest(unittest.TestCase):
         self.assertEqual("INCONCLUSIVE_NOISE_OR_NO_GAIN", gate.INCONCLUSIVE)
         self.assertEqual("FAIL_REGRESSION_OR_BEHAVIOR", gate.FAIL)
 
+    def test_every_profile_has_valid_primary_thresholds(self) -> None:
+        benchmark_index = {entry["id"]: entry for entry in self.config["benchmarks"]}
+        for profile_name, profile in self.config["profiles"].items():
+            with self.subTest(profile=profile_name):
+                benchmark_specs = [benchmark_index[entry] for entry in profile["benchmark_ids"]]
+                gate.validate_profile_config(self.config, profile_name, benchmark_specs)
+
+    def test_profile_validation_rejects_minimum_above_primary_count(self) -> None:
+        config = json.loads(json.dumps(self.config))
+        profile_name = "display-spawn"
+        config["profiles"][profile_name]["minimum_passes"] = 2
+        benchmark_index = {entry["id"]: entry for entry in config["benchmarks"]}
+        benchmark_specs = [
+            benchmark_index[entry]
+            for entry in config["profiles"][profile_name]["benchmark_ids"]
+        ]
+        with self.assertRaisesRegex(ValueError, "invalid primary minimum_passes"):
+            gate.validate_profile_config(config, profile_name, benchmark_specs)
+
 
 class MatrixScheduleTest(unittest.TestCase):
     def test_ab_schedule_is_exactly_four_interleaved_ab_and_ba_pairs(self) -> None:


### PR DESCRIPTION
## Summary

- set `display-spawn` and `region-queue` `minimum_passes` to `1`, matching their single primary time metric
- extract reusable profile validation for `minimum_passes` and `must_pass`
- validate every configured profile in the base-owned statistics test suite

## Context

Trusted A/B decision jobs for these profiles rejected the base-owned configuration with `invalid primary minimum_passes` after completing the benchmark matrix. This fixes the schema mismatch and prevents the same class of configuration error from reaching the benchmark stage again.

## Validation

Build and tests are intentionally delegated to GitHub Actions; no local Gradle, JMH, or server process was run.