### PR TITLE
perf(runtime): cache scheduler reflection capabilities

### DIFF
--- a/src/main/java/top/ellan/mahjong/runtime/ServerScheduler.java
+++ b/src/main/java/top/ellan/mahjong/runtime/ServerScheduler.java
@@ -22,6 +22,38 @@ public final class ServerScheduler {
         }
     };
 
+    private static final ClassValue<ServerCapabilities> SERVER_CAPABILITIES = new ClassValue<>() {
+        @Override
+        protected ServerCapabilities computeValue(Class<?> type) {
+            return new ServerCapabilities(
+                findMethod(type, "getGlobalRegionScheduler"),
+                findMethod(type, "getRegionScheduler")
+            );
+        }
+    };
+    private static final ClassValue<EntityCapabilities> ENTITY_CAPABILITIES = new ClassValue<>() {
+        @Override
+        protected EntityCapabilities computeValue(Class<?> type) {
+            return new EntityCapabilities(
+                findMethod(type, "getScheduler")
+            );
+        }
+    };
+    private static final ClassValue<SchedulerCapabilities> SCHEDULER_CAPABILITIES = new ClassValue<>() {
+        @Override
+        protected SchedulerCapabilities computeValue(Class<?> type) {
+            return new SchedulerCapabilities(
+                findMethod(type, "run", Plugin.class, Consumer.class),
+                findMethod(type, "runDelayed", Plugin.class, Consumer.class, long.class),
+                findMethod(type, "runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class),
+                findMethod(type, "run", Plugin.class, Location.class, Consumer.class),
+                findMethod(type, "runDelayed", Plugin.class, Location.class, Consumer.class, long.class),
+                findMethod(type, "runAtFixedRate", Plugin.class, Location.class, Consumer.class, long.class, long.class),
+                findMethod(type, "run", Plugin.class, Consumer.class, Runnable.class),
+                findMethod(type, "runDelayed", Plugin.class, Consumer.class, Runnable.class, long.class)
+            );
+        }
+    };
     private final Plugin plugin;
 
     public ServerScheduler(Plugin plugin) {
@@ -34,10 +66,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.globalRegionScheduler();
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).globalRun();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "run",
-                new Class<?>[] {Plugin.class, Consumer.class},
+                method,
                 this.plugin,
                 taskConsumer(runnable)
             );
@@ -54,10 +86,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.globalRegionScheduler();
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).globalDelayed();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "runDelayed",
-                new Class<?>[] {Plugin.class, Consumer.class, long.class},
+                method,
                 this.plugin,
                 taskConsumer(runnable),
                 delayTicks
@@ -75,10 +107,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.globalRegionScheduler();
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).globalTimer();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "runAtFixedRate",
-                new Class<?>[] {Plugin.class, Consumer.class, long.class, long.class},
+                method,
                 this.plugin,
                 taskConsumer(runnable),
                 delayTicks,
@@ -97,10 +129,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.regionScheduler();
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).regionRun();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "run",
-                new Class<?>[] {Plugin.class, Location.class, Consumer.class},
+                method,
                 this.plugin,
                 location,
                 taskConsumer(runnable)
@@ -118,10 +150,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.regionScheduler();
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).regionDelayed();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "runDelayed",
-                new Class<?>[] {Plugin.class, Location.class, Consumer.class, long.class},
+                method,
                 this.plugin,
                 location,
                 taskConsumer(runnable),
@@ -140,10 +172,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.regionScheduler();
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).regionTimer();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "runAtFixedRate",
-                new Class<?>[] {Plugin.class, Location.class, Consumer.class, long.class, long.class},
+                method,
                 this.plugin,
                 location,
                 taskConsumer(runnable),
@@ -163,10 +195,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.entityScheduler(entity);
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).entityRun();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "run",
-                new Class<?>[] {Plugin.class, Consumer.class, Runnable.class},
+                method,
                 this.plugin,
                 taskConsumer(runnable),
                 NO_OP_RUNNABLE
@@ -184,10 +216,10 @@ public final class ServerScheduler {
         }
         Object scheduler = this.entityScheduler(entity);
         if (scheduler != null) {
+            Method method = SCHEDULER_CAPABILITIES.get(scheduler.getClass()).entityDelayed();
             PluginTask task = this.invokeSchedulerTask(
                 scheduler,
-                "runDelayed",
-                new Class<?>[] {Plugin.class, Consumer.class, Runnable.class, long.class},
+                method,
                 this.plugin,
                 taskConsumer(runnable),
                 NO_OP_RUNNABLE,
@@ -246,40 +278,44 @@ public final class ServerScheduler {
     }
 
     private Object globalRegionScheduler() {
-        return this.invokeNoArgs(this.plugin.getServer(), "getGlobalRegionScheduler");
+        Object server = this.plugin.getServer();
+        Method method = server == null ? null : SERVER_CAPABILITIES.get(server.getClass()).globalRegionScheduler();
+        return this.invokeNoArgs(server, method);
     }
 
     private Object regionScheduler() {
-        return this.invokeNoArgs(this.plugin.getServer(), "getRegionScheduler");
+        Object server = this.plugin.getServer();
+        Method method = server == null ? null : SERVER_CAPABILITIES.get(server.getClass()).regionScheduler();
+        return this.invokeNoArgs(server, method);
     }
 
     private Object entityScheduler(Entity entity) {
-        return this.invokeNoArgs(entity, "getScheduler");
+        Method method = entity == null ? null : ENTITY_CAPABILITIES.get(entity.getClass()).scheduler();
+        return this.invokeNoArgs(entity, method);
     }
 
     private boolean isPluginEnabled() {
         return this.plugin.isEnabled();
     }
 
-    private Object invokeNoArgs(Object target, String methodName) {
-        if (target == null) {
+    private Object invokeNoArgs(Object target, Method method) {
+        if (target == null || method == null) {
             return null;
         }
         try {
-            Method method = target.getClass().getMethod(methodName);
-            method.setAccessible(true);
             return method.invoke(target);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | RuntimeException exception) {
+        } catch (IllegalAccessException | InvocationTargetException | RuntimeException exception) {
             return null;
         }
     }
 
-    private PluginTask invokeSchedulerTask(Object scheduler, String methodName, Class<?>[] parameterTypes, Object... args) {
+    private PluginTask invokeSchedulerTask(Object scheduler, Method method, Object... args) {
+        if (method == null) {
+            return null;
+        }
         try {
-            Method method = scheduler.getClass().getMethod(methodName, parameterTypes);
-            method.setAccessible(true);
             return wrap(method.invoke(scheduler, args));
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | RuntimeException exception) {
+        } catch (IllegalAccessException | InvocationTargetException | RuntimeException exception) {
             return null;
         }
     }
@@ -334,7 +370,34 @@ public final class ServerScheduler {
         }
     }
 
+    private static Method findMethod(Class<?> type, String methodName, Class<?>... parameterTypes) {
+        try {
+            Method method = type.getMethod(methodName, parameterTypes);
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException | RuntimeException exception) {
+            return null;
+        }
+    }
+
+    private record ServerCapabilities(Method globalRegionScheduler, Method regionScheduler) {
+    }
+
+    private record EntityCapabilities(Method scheduler) {
+    }
+
+    private record SchedulerCapabilities(
+        Method globalRun,
+        Method globalDelayed,
+        Method globalTimer,
+        Method regionRun,
+        Method regionDelayed,
+        Method regionTimer,
+        Method entityRun,
+        Method entityDelayed
+    ) {
+    }
+
     private static final Runnable NO_OP_RUNNABLE = () -> {
     };
 }
-

--- a/src/test/java/top/ellan/mahjong/runtime/ServerSchedulerCapabilityCacheTest.java
+++ b/src/test/java/top/ellan/mahjong/runtime/ServerSchedulerCapabilityCacheTest.java
@@ -155,6 +155,7 @@ class ServerSchedulerCapabilityCacheTest {
             new ServerScheduler(plugin),
             entity,
             new Location(world, 8.0, 64.0, -8.0),
+            world,
             foliaInvocations,
             paperInvocations
         );
@@ -303,6 +304,7 @@ class ServerSchedulerCapabilityCacheTest {
         ServerScheduler scheduler,
         Entity entity,
         Location location,
+        World world,
         Counter foliaInvocations,
         Counter paperInvocations
     ) {

--- a/src/test/java/top/ellan/mahjong/runtime/ServerSchedulerCapabilityCacheTest.java
+++ b/src/test/java/top/ellan/mahjong/runtime/ServerSchedulerCapabilityCacheTest.java
@@ -1,0 +1,310 @@
+package top.ellan.mahjong.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.function.Consumer;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.junit.jupiter.api.Test;
+
+class ServerSchedulerCapabilityCacheTest {
+    private static final Runnable NO_OP = () -> {
+    };
+
+    @Test
+    void routesEveryFoliaSignatureThroughItsReflectiveCapability() {
+        Harness harness = foliaHarness(false);
+
+        invokeEverySignature(harness);
+        invokeEverySignature(harness);
+
+        assertEquals(16, harness.foliaInvocations.value);
+        assertEquals(0, harness.paperInvocations.value);
+    }
+
+    @Test
+    void preservesPaperFallbackWhenCapabilitiesAreAbsent() {
+        Harness harness = paperHarness();
+
+        invokeEverySignature(harness);
+        invokeEverySignature(harness);
+
+        assertEquals(0, harness.foliaInvocations.value);
+        assertEquals(16, harness.paperInvocations.value);
+    }
+
+    @Test
+    void preservesPaperFallbackWhenAReflectiveCapabilityThrows() {
+        Harness harness = foliaHarness(true);
+
+        assertActive(harness.scheduler.runGlobal(NO_OP));
+        assertActive(harness.scheduler.runGlobal(NO_OP));
+
+        assertEquals(2, harness.foliaInvocations.value);
+        assertEquals(2, harness.paperInvocations.value);
+    }
+
+    private static void invokeEverySignature(Harness harness) {
+        assertActive(harness.scheduler.runGlobal(NO_OP));
+        assertActive(harness.scheduler.runGlobalDelayed(NO_OP, 1L));
+        assertActive(harness.scheduler.runGlobalTimer(NO_OP, 1L, 2L));
+        assertActive(harness.scheduler.runRegion(harness.location, NO_OP));
+        assertActive(harness.scheduler.runRegionDelayed(harness.location, NO_OP, 1L));
+        assertActive(harness.scheduler.runRegionTimer(harness.location, NO_OP, 1L, 2L));
+        assertActive(harness.scheduler.runEntity(harness.entity, NO_OP));
+        assertActive(harness.scheduler.runEntityDelayed(harness.entity, NO_OP, 1L));
+    }
+
+    private static void assertActive(PluginTask task) {
+        assertFalse(task.isCancelled());
+    }
+
+    private static Harness foliaHarness(boolean throwGlobal) {
+        Counter foliaInvocations = new Counter();
+        Counter paperInvocations = new Counter();
+        BukkitScheduler bukkitScheduler = bukkitScheduler(paperInvocations);
+        Object globalScheduler = schedulerProxy(
+            capabilityReturnType(Server.class, "getGlobalRegionScheduler"),
+            new Class<?>[] {Plugin.class, Consumer.class},
+            foliaInvocations,
+            throwGlobal
+        );
+        Object regionScheduler = schedulerProxy(
+            capabilityReturnType(Server.class, "getRegionScheduler"),
+            new Class<?>[] {Plugin.class, Location.class, Consumer.class},
+            foliaInvocations,
+            false
+        );
+        Object entityScheduler = schedulerProxy(
+            capabilityReturnType(Entity.class, "getScheduler"),
+            new Class<?>[] {Plugin.class, Consumer.class, Runnable.class},
+            foliaInvocations,
+            false
+        );
+        Server server = proxy(
+            Server.class,
+            (instance, method, arguments) -> switch (method.getName()) {
+                case "getGlobalRegionScheduler" -> globalScheduler;
+                case "getRegionScheduler" -> regionScheduler;
+                case "getScheduler" -> bukkitScheduler;
+                default -> unsupported(instance, method, arguments);
+            }
+        );
+        Entity entity = proxy(
+            Entity.class,
+            (instance, method, arguments) -> {
+                if (method.getName().equals("getScheduler") && method.getParameterCount() == 0) {
+                    return entityScheduler;
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+        return harness(server, entity, foliaInvocations, paperInvocations);
+    }
+
+    private static Harness paperHarness() {
+        Counter paperInvocations = new Counter();
+        BukkitScheduler bukkitScheduler = bukkitScheduler(paperInvocations);
+        Server server = proxy(
+            Server.class,
+            (instance, method, arguments) -> {
+                if (
+                    (method.getName().equals("getGlobalRegionScheduler") || method.getName().equals("getRegionScheduler"))
+                        && method.getParameterCount() == 0
+                ) {
+                    return null;
+                }
+                if (method.getName().equals("getScheduler") && method.getParameterCount() == 0) {
+                    return bukkitScheduler;
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+        Entity entity = proxy(
+            Entity.class,
+            (instance, method, arguments) -> {
+                if (method.getName().equals("getScheduler") && method.getParameterCount() == 0) {
+                    return null;
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+        return harness(server, entity, new Counter(), paperInvocations);
+    }
+
+    private static Harness harness(Server server, Entity entity, Counter foliaInvocations, Counter paperInvocations) {
+        Plugin plugin = proxy(
+            Plugin.class,
+            (instance, method, arguments) -> switch (method.getName()) {
+                case "isEnabled" -> true;
+                case "getServer" -> server;
+                default -> unsupported(instance, method, arguments);
+            }
+        );
+        World world = proxy(World.class, ServerSchedulerCapabilityCacheTest::unsupported);
+        return new Harness(
+            new ServerScheduler(plugin),
+            entity,
+            new Location(world, 8.0, 64.0, -8.0),
+            foliaInvocations,
+            paperInvocations
+        );
+    }
+
+    private static Object schedulerProxy(
+        Class<?> schedulerType,
+        Class<?>[] runParameters,
+        Counter invocations,
+        boolean throwOnRun
+    ) {
+        Class<?> taskType;
+        try {
+            taskType = schedulerType.getMethod("run", runParameters).getReturnType();
+        } catch (NoSuchMethodException exception) {
+            throw new IllegalStateException("Scheduler contract changed: " + schedulerType.getName(), exception);
+        }
+        Object task = interfaceProxy(
+            taskType,
+            (instance, method, arguments) -> {
+                if (method.getName().equals("isCancelled") || method.getName().equals("cancel")) {
+                    return defaultValue(method.getReturnType());
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+        return interfaceProxy(
+            schedulerType,
+            (instance, method, arguments) -> {
+                if (method.getName().startsWith("run")) {
+                    invocations.value++;
+                    if (throwOnRun) {
+                        throw new IllegalStateException("expected test failure");
+                    }
+                    return task;
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+    }
+
+    private static Class<?> capabilityReturnType(Class<?> owner, String methodName) {
+        try {
+            return owner.getMethod(methodName).getReturnType();
+        } catch (NoSuchMethodException exception) {
+            throw new IllegalStateException("Paper scheduler capability is unavailable: " + methodName, exception);
+        }
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0.0F;
+        }
+        if (type == double.class) {
+            return 0.0D;
+        }
+        throw new IllegalStateException("Unknown primitive return type: " + type.getName());
+    }
+
+    private static BukkitScheduler bukkitScheduler(Counter invocations) {
+        BukkitTask task = proxy(
+            BukkitTask.class,
+            (instance, method, arguments) -> {
+                if (method.getName().equals("isCancelled") && method.getParameterCount() == 0) {
+                    return false;
+                }
+                if (method.getName().equals("cancel") && method.getParameterCount() == 0) {
+                    return null;
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+        return proxy(
+            BukkitScheduler.class,
+            (instance, method, arguments) -> {
+                if (method.getName().startsWith("runTask")) {
+                    invocations.value++;
+                    return task;
+                }
+                return unsupported(instance, method, arguments);
+            }
+        );
+    }
+
+    private static Object unsupported(Object instance, Method method, Object[] arguments) {
+        if (method.getDeclaringClass() == Object.class) {
+            return switch (method.getName()) {
+                case "equals" -> instance == arguments[0];
+                case "hashCode" -> System.identityHashCode(instance);
+                case "toString" -> instance.getClass().getInterfaces()[0].getSimpleName() + "Proxy";
+                default -> throw new UnsupportedOperationException(method.toString());
+            };
+        }
+        throw new UnsupportedOperationException(method.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> primary, InvocationHandler handler, Class<?>... additionalInterfaces) {
+        Class<?>[] interfaces = new Class<?>[additionalInterfaces.length + 1];
+        interfaces[0] = primary;
+        System.arraycopy(additionalInterfaces, 0, interfaces, 1, additionalInterfaces.length);
+        return (T) Proxy.newProxyInstance(
+            ServerSchedulerCapabilityCacheTest.class.getClassLoader(),
+            interfaces,
+            handler
+        );
+    }
+
+    private static Object interfaceProxy(Class<?> type, InvocationHandler handler) {
+        if (!type.isInterface()) {
+            throw new IllegalStateException("Expected an interface capability: " + type.getName());
+        }
+        return Proxy.newProxyInstance(
+            ServerSchedulerCapabilityCacheTest.class.getClassLoader(),
+            new Class<?>[] {type},
+            handler
+        );
+    }
+
+    private static final class Counter {
+        private int value;
+    }
+
+    private record Harness(
+        ServerScheduler scheduler,
+        Entity entity,
+        Location location,
+        Counter foliaInvocations,
+        Counter paperInvocations
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary

- cache server, region, entity, and scheduler capability methods per runtime class with `ClassValue`
- preserve the existing Folia-style reflection route and Paper fallback behavior
- avoid caching scheduler instances and retain classloader-safe cache ownership
- cover all eight reflected scheduling signatures plus missing/null and throwing fallbacks

## Measurement

This is a single production candidate against the merged `scheduler-reflection` base-owned JMH profile. Build and tests run first; paired A/B is enabled only after those checks pass.

## Validation

No Gradle, JMH, tests, server, or client workload was run locally. Compilation, tests, and performance measurement are GitHub-only.