### PR TITLE
fix(perf): retain scheduler benchmark world

### DIFF
--- a/src/perfTest/java/top/ellan/mahjong/perf/ServerSchedulerReflectionBenchmark.java
+++ b/src/perfTest/java/top/ellan/mahjong/perf/ServerSchedulerReflectionBenchmark.java
@@ -39,12 +39,13 @@ public class ServerSchedulerReflectionBenchmark {
 
     private Harness folia;
     private Harness paper;
+    private World world;
     private Location location;
 
     @Setup(Level.Trial)
     public void setUp() {
-        World world = proxy(World.class, ServerSchedulerReflectionBenchmark::unsupported);
-        this.location = new Location(world, 8.0, 64.0, -8.0);
+        this.world = proxy(World.class, ServerSchedulerReflectionBenchmark::unsupported);
+        this.location = new Location(this.world, 8.0, 64.0, -8.0);
         this.folia = createFoliaHarness();
         this.paper = createPaperHarness();
         this.verifyContract();


### PR DESCRIPTION
## Root cause

The first trusted `scheduler-reflection` A/A warmup failed before producing any samples. `Location` keeps its `World` through a weak reference, while the benchmark fixture kept the dynamic world proxy only in a setup-local variable. Forced GC between setup and measurement could clear it, making `Location.getWorld()` throw `IllegalArgumentException: World unloaded`.

Evidence: GitHub run `29479927670`, raw artifact `8368125446`, log `aa/logs/aa-pair-01-pos-1-baseline_a.log`.

## Fix

Keep the world proxy as a `@State(Scope.Thread)` field for the full JMH trial and build the same real `Location` from that strong reference. Production `ServerScheduler` is unchanged.

## Validation

No local Gradle, JMH, test, server, or client process was run. GitHub must compile the harness and run every protected benchmark smoke before this measurement-only fix can merge. Afterward #72 will be rebased and its A/A/A-B restarted from scratch.