### PR TITLE
perf(render): cache production region keys

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -39,6 +39,30 @@ public final class TableRegionDisplayCoordinator {
     private static final int PRIORITY_TURN_STATE = 240;
     private static final int PRIORITY_BOARD = 160;
     private static final int PRIORITY_BACKGROUND = 80;
+    private static final String[] VISUAL_REGION_KEYS = createSeatRegionKeys("visual");
+    private static final String[] LABEL_REGION_KEYS = createSeatRegionKeys("labels");
+    private static final String[] STICK_REGION_KEYS = createSeatRegionKeys("sticks");
+    private static final String[] HAND_PUBLIC_REGION_KEYS = createSeatRegionKeys("hand-public");
+    private static final String[] HAND_PRIVATE_REGION_KEYS = createSeatRegionKeys("hand-private");
+    private static final String[] DISCARD_REGION_KEYS = createSeatRegionKeys("discards");
+    private static final String[] MELD_REGION_KEYS = createSeatRegionKeys("melds");
+    private static final String[][] HAND_PUBLIC_TILE_REGION_KEYS = createIndexedSeatRegionKeys(
+        "hand-public",
+        MAX_HAND_TILE_REGIONS
+    );
+    private static final String[][] HAND_PRIVATE_TILE_REGION_KEYS = createIndexedSeatRegionKeys(
+        "hand-private",
+        MAX_HAND_TILE_REGIONS
+    );
+    private static final String[][] DISCARD_TILE_REGION_KEYS = createIndexedSeatRegionKeys(
+        "discards",
+        MAX_DISCARD_TILE_REGIONS
+    );
+    private static final String[][] MELD_TILE_REGION_KEYS = createIndexedSeatRegionKeys(
+        "melds",
+        MAX_MELD_TILE_REGIONS
+    );
+    private static final String[] WALL_TILE_REGION_KEYS = createIndexedRegionKeys(REGION_WALL, MAX_WALL_TILE_REGIONS);
     private static final int[] APPLY_PRIORITY_ORDER = {
         PRIORITY_REACTION_PROMPT,
         PRIORITY_HAND,
@@ -645,27 +669,91 @@ public final class TableRegionDisplayCoordinator {
     }
 
     private String seatRegionKey(String region, SeatWind wind) {
+        if ("visual".equals(region)) {
+            return VISUAL_REGION_KEYS[wind.index()];
+        }
+        if ("labels".equals(region)) {
+            return LABEL_REGION_KEYS[wind.index()];
+        }
+        if ("sticks".equals(region)) {
+            return STICK_REGION_KEYS[wind.index()];
+        }
+        if ("hand-public".equals(region)) {
+            return HAND_PUBLIC_REGION_KEYS[wind.index()];
+        }
+        if ("hand-private".equals(region)) {
+            return HAND_PRIVATE_REGION_KEYS[wind.index()];
+        }
+        if ("discards".equals(region)) {
+            return DISCARD_REGION_KEYS[wind.index()];
+        }
+        if ("melds".equals(region)) {
+            return MELD_REGION_KEYS[wind.index()];
+        }
         return region + ":" + wind.name();
     }
 
     private String handPrivateRegionKey(SeatWind wind, int tileIndex) {
+        if (tileIndex >= 0 && tileIndex < MAX_HAND_TILE_REGIONS) {
+            return HAND_PRIVATE_TILE_REGION_KEYS[wind.index()][tileIndex];
+        }
         return this.seatRegionKey("hand-private-" + tileIndex, wind);
     }
 
     private String handPublicRegionKey(SeatWind wind, int tileIndex) {
+        if (tileIndex >= 0 && tileIndex < MAX_HAND_TILE_REGIONS) {
+            return HAND_PUBLIC_TILE_REGION_KEYS[wind.index()][tileIndex];
+        }
         return this.seatRegionKey("hand-public-" + tileIndex, wind);
     }
 
     private String discardRegionKey(SeatWind wind, int discardIndex) {
+        if (discardIndex >= 0 && discardIndex < MAX_DISCARD_TILE_REGIONS) {
+            return DISCARD_TILE_REGION_KEYS[wind.index()][discardIndex];
+        }
         return this.seatRegionKey("discards-" + discardIndex, wind);
     }
 
     private String meldRegionKey(SeatWind wind, int meldIndex) {
+        if (meldIndex >= 0 && meldIndex < MAX_MELD_TILE_REGIONS) {
+            return MELD_TILE_REGION_KEYS[wind.index()][meldIndex];
+        }
         return this.seatRegionKey("melds-" + meldIndex, wind);
     }
 
     private String wallRegionKey(int wallIndex) {
+        if (wallIndex >= 0 && wallIndex < MAX_WALL_TILE_REGIONS) {
+            return WALL_TILE_REGION_KEYS[wallIndex];
+        }
         return REGION_WALL + "-" + wallIndex;
+    }
+
+    private static String[] createSeatRegionKeys(String region) {
+        SeatWind[] winds = SeatWind.values();
+        String[] keys = new String[winds.length];
+        for (SeatWind wind : winds) {
+            keys[wind.index()] = region + ":" + wind.name();
+        }
+        return keys;
+    }
+
+    private static String[][] createIndexedSeatRegionKeys(String region, int count) {
+        SeatWind[] winds = SeatWind.values();
+        String[][] keys = new String[winds.length][count];
+        for (SeatWind wind : winds) {
+            for (int index = 0; index < count; index++) {
+                keys[wind.index()][index] = region + "-" + index + ":" + wind.name();
+            }
+        }
+        return keys;
+    }
+
+    private static String[] createIndexedRegionKeys(String region, int count) {
+        String[] keys = new String[count];
+        for (int index = 0; index < count; index++) {
+            keys[index] = region + "-" + index;
+        }
+        return keys;
     }
 
     private static long fingerprintOf(Map<String, Long> fingerprints, String regionKey) {

--- a/src/test/java/top/ellan/mahjong/table/render/TableRegionKeyCacheTest.java
+++ b/src/test/java/top/ellan/mahjong/table/render/TableRegionKeyCacheTest.java
@@ -1,0 +1,117 @@
+package top.ellan.mahjong.table.render;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import top.ellan.mahjong.model.SeatWind;
+
+class TableRegionKeyCacheTest {
+    private static final int EXPECTED_KEY_COUNT = 452;
+
+    @Test
+    void reusesEveryProductionRegionKeyWithoutChangingItsText() throws ReflectiveOperationException {
+        TableRegionDisplayCoordinator coordinator = new TableRegionDisplayCoordinator(null, null);
+        Method seatKey = method("seatRegionKey", String.class, SeatWind.class);
+        Method handPrivateKey = method("handPrivateRegionKey", SeatWind.class, int.class);
+        Method handPublicKey = method("handPublicRegionKey", SeatWind.class, int.class);
+        Method discardKey = method("discardRegionKey", SeatWind.class, int.class);
+        Method meldKey = method("meldRegionKey", SeatWind.class, int.class);
+        Method wallKey = method("wallRegionKey", int.class);
+        Set<String> keys = new HashSet<>(EXPECTED_KEY_COUNT);
+
+        for (int index = 0; index < 136; index++) {
+            this.assertCached(keys, wallKey, "wall-" + index, coordinator, index);
+        }
+        for (SeatWind wind : SeatWind.values()) {
+            String suffix = ":" + wind.name();
+            for (String region : new String[] {
+                "visual", "labels", "sticks", "hand-public", "hand-private", "discards", "melds"
+            }) {
+                this.assertCached(keys, seatKey, region + suffix, coordinator, region, wind);
+            }
+            for (int index = 0; index < 14; index++) {
+                this.assertCached(
+                    keys,
+                    handPublicKey,
+                    "hand-public-" + index + suffix,
+                    coordinator,
+                    wind,
+                    index
+                );
+                this.assertCached(
+                    keys,
+                    handPrivateKey,
+                    "hand-private-" + index + suffix,
+                    coordinator,
+                    wind,
+                    index
+                );
+            }
+            for (int index = 0; index < 24; index++) {
+                this.assertCached(keys, discardKey, "discards-" + index + suffix, coordinator, wind, index);
+            }
+            for (int index = 0; index < 20; index++) {
+                this.assertCached(keys, meldKey, "melds-" + index + suffix, coordinator, wind, index);
+            }
+        }
+
+        assertEquals(EXPECTED_KEY_COUNT, keys.size());
+    }
+
+    @Test
+    void retainsLegacyFallbacksOutsideTheProductionKeyRanges() throws ReflectiveOperationException {
+        TableRegionDisplayCoordinator coordinator = new TableRegionDisplayCoordinator(null, null);
+        SeatWind wind = SeatWind.EAST;
+
+        assertEquals(
+            "viewer-overlay:EAST",
+            invoke(method("seatRegionKey", String.class, SeatWind.class), coordinator, "viewer-overlay", wind)
+        );
+        assertEquals(
+            "hand-private--1:EAST",
+            invoke(method("handPrivateRegionKey", SeatWind.class, int.class), coordinator, wind, -1)
+        );
+        assertEquals(
+            "hand-public-14:EAST",
+            invoke(method("handPublicRegionKey", SeatWind.class, int.class), coordinator, wind, 14)
+        );
+        assertEquals(
+            "discards-24:EAST",
+            invoke(method("discardRegionKey", SeatWind.class, int.class), coordinator, wind, 24)
+        );
+        assertEquals(
+            "melds-20:EAST",
+            invoke(method("meldRegionKey", SeatWind.class, int.class), coordinator, wind, 20)
+        );
+        assertEquals("wall-136", invoke(method("wallRegionKey", int.class), coordinator, 136));
+    }
+
+    private void assertCached(
+        Set<String> keys,
+        Method method,
+        String expected,
+        TableRegionDisplayCoordinator coordinator,
+        Object... arguments
+    ) throws ReflectiveOperationException {
+        String first = invoke(method, coordinator, arguments);
+        String second = invoke(method, coordinator, arguments);
+        assertEquals(expected, first);
+        assertSame(first, second);
+        keys.add(first);
+    }
+
+    private static Method method(String name, Class<?>... parameterTypes) throws NoSuchMethodException {
+        Method method = TableRegionDisplayCoordinator.class.getDeclaredMethod(name, parameterTypes);
+        method.setAccessible(true);
+        return method;
+    }
+
+    private static String invoke(Method method, TableRegionDisplayCoordinator coordinator, Object... arguments)
+        throws ReflectiveOperationException {
+        return (String) method.invoke(coordinator, arguments);
+    }
+}


### PR DESCRIPTION
## Pure performance scope

- precompute the 452 immutable region keys used by one complete table refresh
- index cached keys by seat and bounded tile/discard/meld/wall slot
- preserve the original concatenation fallback for unknown region names and every out-of-range index
- keep all arrays private and expose only the same private String-returning methods

## Behavior proof

Focused tests verify exact text and stable identity for every production key, exactly 452 distinct values, plus legacy unknown-prefix and out-of-range fallbacks. The merged base-owned `region-keys` JMH sentinel independently verifies exact text, order, count, uniqueness, and checksum outside timing.

## Evidence gate

This PR changes only `TableRegionDisplayCoordinator` and its focused test. No benchmark, threshold, workflow, dependency, or configuration is changed. GitHub Build/Test must pass before enabling paired A/B; only `PASS_OPTIMIZED` permits merge.

No Gradle, JMH, test, server, or client workload was run locally.