### PR TITLE
perf(render): reuse static region fingerprint keys

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -14,6 +14,7 @@ public final class TableRegionFingerprintService {
     private static final String REGION_WALL = "wall";
     private static final String REGION_DORA = "dora";
     private static final String REGION_CENTER = "center";
+    private static final SeatRegionKeys[] SEAT_REGION_KEYS = createSeatRegionKeys();
 
     public Map<String, Long> precomputeRegionFingerprints(TableRenderSubject session, TableRenderSnapshot snapshot) {
         Map<String, Long> fingerprints = new HashMap<>();
@@ -23,10 +24,11 @@ public final class TableRegionFingerprintService {
         fingerprints.put(REGION_CENTER, this.centerFingerprint(snapshot));
         for (SeatWind wind : SeatWind.values()) {
             TableSeatRenderSnapshot seat = snapshot.seat(wind);
-            fingerprints.put(this.seatRegionKey("visual", wind), this.seatVisualFingerprint(session, wind));
-            fingerprints.put(this.seatRegionKey("labels", wind), this.seatLabelFingerprint(session, snapshot, seat));
-            fingerprints.put(this.seatRegionKey("sticks", wind), this.stickFingerprint(snapshot, seat));
-            fingerprints.put(this.seatRegionKey("hand-public", wind), this.handPublicFingerprint(snapshot, seat));
+            SeatRegionKeys keys = SEAT_REGION_KEYS[wind.index()];
+            fingerprints.put(keys.visual(), this.seatVisualFingerprint(session, wind));
+            fingerprints.put(keys.labels(), this.seatLabelFingerprint(session, snapshot, seat));
+            fingerprints.put(keys.sticks(), this.stickFingerprint(snapshot, seat));
+            fingerprints.put(keys.handPublic(), this.handPublicFingerprint(snapshot, seat));
         }
         return Map.copyOf(fingerprints);
     }
@@ -250,8 +252,18 @@ public final class TableRegionFingerprintService {
         return builder.value();
     }
 
-    private String seatRegionKey(String region, SeatWind wind) {
-        return region + ":" + wind.name();
+    private static SeatRegionKeys[] createSeatRegionKeys() {
+        SeatWind[] winds = SeatWind.values();
+        SeatRegionKeys[] keys = new SeatRegionKeys[winds.length];
+        for (SeatWind wind : winds) {
+            keys[wind.index()] = new SeatRegionKeys(
+                "visual:" + wind.name(),
+                "labels:" + wind.name(),
+                "sticks:" + wind.name(),
+                "hand-public:" + wind.name()
+            );
+        }
+        return keys;
     }
 
     private static FingerprintBuilder fingerprintBuilder(int capacity) {
@@ -332,5 +344,8 @@ public final class TableRegionFingerprintService {
             this.hash ^= value & 0xffL;
             this.hash *= FNV_PRIME;
         }
+    }
+
+    private record SeatRegionKeys(String visual, String labels, String sticks, String handPublic) {
     }
 }


### PR DESCRIPTION
## Summary

- precompute the fixed visual, label, stick, and public-hand region keys once per seat
- remove per-snapshot string concatenation from region fingerprint precomputation
- preserve the current typed fingerprint encoding introduced by #78
- keep the change isolated to one production file

## Measurement

The previous branch produced an inconclusive A/B result and was not merged. This rebased candidate uses the current `performance-region-fingerprint` JMH profile against the post-#78 `dev` baseline and must remain unmerged unless GitHub reports `PASS_OPTIMIZED`.

## Validation

No Gradle, JMH, tests, server, or client workload was run locally. Compilation, tests, server smoke, and performance measurement are GitHub-only.