### PR TITLE
perf(gb): allocate only the selected discard choice

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -185,7 +185,9 @@ final class GbBotDecisionService {
         if (hand == null || hand.isEmpty()) {
             return null;
         }
-        DiscardChoice best = null;
+        int bestIndex = -1;
+        long bestReadyScore = 0;
+        int bestDiscardPreference = 0;
         EnumMap<MahjongTile, GbTingResponse> tingMemo = new EnumMap<>(MahjongTile.class);
         MahjongTile previousDiscarded = null;
         int previousDiscardPreference = 0;
@@ -205,14 +207,17 @@ final class GbBotDecisionService {
             int candidateDiscardPreference = tingMemoHit && discarded == previousDiscarded
                 ? previousDiscardPreference
                 : discardPreference(hand, discarded);
-            DiscardChoice candidate = new DiscardChoice(i, candidateReadyScore, candidateDiscardPreference);
             previousDiscarded = discarded;
             previousDiscardPreference = candidateDiscardPreference;
-            if (best == null || candidate.compareTo(best) > 0) {
-                best = candidate;
+            if (bestIndex < 0
+                || candidateReadyScore > bestReadyScore
+                || (candidateReadyScore == bestReadyScore && candidateDiscardPreference > bestDiscardPreference)) {
+                bestIndex = i;
+                bestReadyScore = candidateReadyScore;
+                bestDiscardPreference = candidateDiscardPreference;
             }
         }
-        return best;
+        return bestIndex < 0 ? null : new DiscardChoice(bestIndex, bestReadyScore, bestDiscardPreference);
     }
 
     private BotState simulateKan(List<MahjongTile> sourceHand, List<GbMeldState> sourceMelds, MahjongTile target) {

--- a/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
@@ -46,6 +46,64 @@ class GbBotDecisionServiceTest {
     }
 
     @Test
+    fun `discard suggestion compares ready score before discard preference`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.EAST, MahjongTile.M2, MahjongTile.M3)
+        val ready = GbTingResponse(true, listOf(GbTingCandidate("W1", 8)), null)
+        assertTrue(
+            GbBotDecisionService.discardPreference(hand, MahjongTile.EAST) >
+                GbBotDecisionService.discardPreference(hand, MahjongTile.M2),
+        )
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
+                if (MahjongTile.M2 !in remaining) {
+                    ready
+                } else {
+                    GbTingResponse(true, emptyList(), null)
+                }
+            }
+
+        assertEquals(1, suggestedIndex)
+    }
+
+    @Test
+    fun `discard suggestion compares discard preference after equal ready scores`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M2, MahjongTile.M3, MahjongTile.EAST)
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { _, _ ->
+                GbTingResponse(true, emptyList(), null)
+            }
+
+        assertEquals(2, suggestedIndex)
+    }
+
+    @Test
+    fun `discard suggestion evaluates unique candidates in hand order`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M1, MahjongTile.P1, MahjongTile.S1)
+        val evaluatedHands = mutableListOf<List<MahjongTile>>()
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
+                evaluatedHands += remaining.toList()
+                GbTingResponse(true, emptyList(), null)
+            }
+
+        assertEquals(0, suggestedIndex)
+        assertEquals(
+            listOf(
+                listOf(MahjongTile.P1, MahjongTile.S1),
+                listOf(MahjongTile.M1, MahjongTile.S1),
+                listOf(MahjongTile.M1, MahjongTile.P1),
+            ),
+            evaluatedHands,
+        )
+    }
+
+    @Test
     fun `discard suggestion evaluates the first remaining hand once per duplicated tile`() {
         val service = GbBotDecisionService(8)
         val hand = listOf(MahjongTile.M1, MahjongTile.M2, MahjongTile.M1)


### PR DESCRIPTION
## Summary

- keep the best discard candidate as primitive loop state
- allocate one `DiscardChoice` only after the winning index and scores are known
- preserve ready-score priority, discard-preference tie-breaking, first-winner ordering, and ting-evaluation counts
- recover the three focused comparison/order regression tests from the unsubmitted `codex/perf-gb-primitive-best` branch

## Measurement

The protected `performance-gb-bot` JMH profile is the authoritative A/B measurement against the current `dev` baseline. This PR must remain unmerged unless GitHub reports `PASS_OPTIMIZED`.

## Validation

No Gradle, JMH, tests, server, or client workload was run locally. Compilation, recovered behavioral tests, all platform builds, and performance measurement are GitHub-only.