### PR TITLE
perf(gb): index ting memo by tile ordinal

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -9,12 +9,13 @@ import top.ellan.mahjong.riichi.ReactionOptions;
 import top.ellan.mahjong.riichi.ReactionResponse;
 import top.ellan.mahjong.riichi.ReactionResponses;
 import java.util.ArrayList;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
 import kotlin.Pair;
 
 final class GbBotDecisionService {
+    private static final int TILE_KIND_COUNT = MahjongTile.values().length;
+
     private final int minimumFan;
 
     GbBotDecisionService(int minimumFan) {
@@ -188,19 +189,20 @@ final class GbBotDecisionService {
         int bestIndex = -1;
         long bestReadyScore = 0;
         int bestDiscardPreference = 0;
-        EnumMap<MahjongTile, GbTingResponse> tingMemo = new EnumMap<>(MahjongTile.class);
+        GbTingResponse[] tingMemo = new GbTingResponse[TILE_KIND_COUNT];
         MahjongTile previousDiscarded = null;
         int previousDiscardPreference = 0;
         for (int i = 0; i < hand.size(); i++) {
             MahjongTile discarded = hand.get(i);
-            GbTingResponse ting = tingMemo.get(discarded);
+            int discardedOrdinal = discarded.ordinal();
+            GbTingResponse ting = tingMemo[discardedOrdinal];
             boolean tingMemoHit = ting != null;
             if (ting == null) {
                 List<MahjongTile> remaining = new ArrayList<>(hand);
                 remaining.remove(i);
                 ting = tingEvaluator.evaluate(remaining, melds);
                 if (ting != null) {
-                    tingMemo.put(discarded, ting);
+                    tingMemo[discardedOrdinal] = ting;
                 }
             }
             long candidateReadyScore = readyScore(ting);

--- a/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/core/round/GbBotDecisionServiceTest.kt
@@ -124,6 +124,27 @@ class GbBotDecisionServiceTest {
     }
 
     @Test
+    fun `discard suggestion keeps ordinal memo entries isolated across suits`() {
+        val service = GbBotDecisionService(8)
+        val hand = listOf(MahjongTile.M1, MahjongTile.P1, MahjongTile.M1, MahjongTile.P1)
+        val ready = GbTingResponse(true, listOf(GbTingCandidate("W1", 8)), null)
+        var evaluations = 0
+
+        val suggestedIndex =
+            service.suggestedDiscardIndex(hand, emptyList()) { remaining, _ ->
+                evaluations++
+                if (remaining.count { it == MahjongTile.P1 } == 2) {
+                    ready
+                } else {
+                    GbTingResponse(true, emptyList(), null)
+                }
+            }
+
+        assertEquals(0, suggestedIndex)
+        assertEquals(2, evaluations)
+    }
+
+    @Test
     fun `discard suggestion keeps the earliest index for equal duplicate candidates`() {
         val service = GbBotDecisionService(8)
         val hand = listOf(MahjongTile.M1, MahjongTile.M1, MahjongTile.M1)


### PR DESCRIPTION
## Summary

- replace the per-decision `EnumMap` wrapper with a fixed `GbTingResponse[]`
- index memoized responses by `MahjongTile.ordinal()` while retaining null-response recomputation
- preserve exact tile-kind separation, evaluator counts, hand ordering, and selection behavior
- recover the focused cross-suit regression test from the unsubmitted `codex/perf-gb-ordinal-memo` branch on top of current `dev`

## Measurement

The protected `performance-gb-bot` JMH profile is authoritative across duplicate, mixed, and unique hands. This PR must remain unmerged unless GitHub reports `PASS_OPTIMIZED`.

## Validation

No Gradle, JMH, tests, server, or client workload was run locally. Behavioral tests, all platform builds, and performance measurement are GitHub-only.