### PR TITLE
fix(ci): make release promotion skip-proof

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 
 on:
-  pull_request:
+  # pull_request_target is intentional: pull_request workflows are suppressed when the
+  # promoted dev HEAD carries a CI skip marker. The release job still rejects everything
+  # except an already-merged, same-repository dev -> main pull request.
+  pull_request_target:
     branches:
       - main
     types:


### PR DESCRIPTION
## Root cause
GitHub skips `pull_request` workflows when the pull request HEAD commit contains a CI skip marker. The validated #93 merge intentionally used `[skip ci]`, so closing the subsequent dev-to-main promotion did not create the Release run.

## Fix
- trigger the release promotion gate with `pull_request_target: closed`
- retain the existing strict guard: merged, same repository, head `dev`, base `main`
- keep build jobs read-only; `contents: write` remains isolated to the final trusted release job

GitHub documents `pull_request_target: closed` as the merge trigger and explicitly states that CI skip annotations do not suppress `pull_request_target` runs.

## Validation
- independent security review found no must-fix or untrusted-write-token path
- `git diff --check` passed
- no local build was run, per repository validation policy