### PR TITLE
chore: finalize v1.5.0 promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 
 on:
-  pull_request:
+  # pull_request_target is intentional: pull_request workflows are suppressed when the
+  # promoted dev HEAD carries a CI skip marker. The release job still rejects everything
+  # except an already-merged, same-repository dev -> main pull request.
+  pull_request_target:
     branches:
       - main
     types:


### PR DESCRIPTION
## Summary
Promote the skip-proof Release trigger from `dev` to `main` and publish v1.5.0 from the resulting merge commit.

The previous promotion merged the complete feature tree, but its `pull_request` Release event was suppressed because the dev HEAD carried a CI skip marker. PR #94 fixes the root cause with a strictly guarded `pull_request_target: closed` trigger.

## Release invariants
- same-repository `dev` head only
- `main` base only
- merged pull requests only
- read-only build token; write token isolated to final tag/release job
- v1.5.0 tag and release do not yet exist