### PR TITLE
perf(render): skip unchanged ray lifecycle work

### DIFF
--- a/src/main/java/top/ellan/mahjong/render/display/DisplayInteractionRayRegistry.java
+++ b/src/main/java/top/ellan/mahjong/render/display/DisplayInteractionRayRegistry.java
@@ -46,15 +46,19 @@ public final class DisplayInteractionRayRegistry {
             return;
         }
         VIEWER_INTERACTIONS.compute(viewerId, (ignored, current) -> {
-            if (current != null && !tableId.equals(current.tableId())) {
-                return interactions == null || interactions.isEmpty()
-                    ? current
-                    : ViewerInteractions.single(tableId, regionKey, interactions);
+            boolean empty = interactions == null || interactions.isEmpty();
+            if (current == null) {
+                return empty ? null : ViewerInteractions.single(tableId, regionKey, interactions);
             }
-            Map<String, List<RayInteraction>> regions = current == null
-                ? new LinkedHashMap<>()
-                : new LinkedHashMap<>(current.regions());
-            if (interactions == null || interactions.isEmpty()) {
+            if (!tableId.equals(current.tableId())) {
+                return empty ? current : ViewerInteractions.single(tableId, regionKey, interactions);
+            }
+            List<RayInteraction> previous = current.regions().get(regionKey);
+            if ((empty && previous == null) || (!empty && Objects.equals(previous, interactions))) {
+                return current;
+            }
+            Map<String, List<RayInteraction>> regions = new LinkedHashMap<>(current.regions());
+            if (empty) {
                 regions.remove(regionKey);
             } else {
                 regions.put(regionKey, List.copyOf(interactions));
@@ -129,11 +133,11 @@ public final class DisplayInteractionRayRegistry {
             return;
         }
         PublicRegionKey key = new PublicRegionKey(tableId, regionKey);
-        List<RayInteraction> publicJoins = interactions == null
-            ? List.of()
-            : interactions.stream()
-                .filter(interaction -> isPublicJoinForTable(interaction, tableId))
-                .toList();
+        List<RayInteraction> previous = PUBLIC_JOIN_REGIONS.get(key);
+        if (samePublicJoinInteractions(previous, tableId, interactions)) {
+            return;
+        }
+        List<RayInteraction> publicJoins = filterPublicJoinInteractions(tableId, interactions);
         if (publicJoins.isEmpty()) {
             PUBLIC_JOIN_REGIONS.remove(key);
         } else {
@@ -209,6 +213,44 @@ public final class DisplayInteractionRayRegistry {
         List<RayInteraction> flattened = new ArrayList<>();
         PUBLIC_JOIN_REGIONS.values().forEach(flattened::addAll);
         publicJoinInteractions = List.copyOf(flattened);
+    }
+
+    private static boolean samePublicJoinInteractions(
+        List<RayInteraction> previous,
+        String tableId,
+        List<RayInteraction> interactions
+    ) {
+        int previousIndex = 0;
+        if (interactions != null) {
+            for (RayInteraction interaction : interactions) {
+                if (!isPublicJoinForTable(interaction, tableId)) {
+                    continue;
+                }
+                if (previous == null
+                    || previousIndex >= previous.size()
+                    || !Objects.equals(previous.get(previousIndex), interaction)) {
+                    return false;
+                }
+                previousIndex++;
+            }
+        }
+        return previous == null ? previousIndex == 0 : previousIndex == previous.size();
+    }
+
+    private static List<RayInteraction> filterPublicJoinInteractions(
+        String tableId,
+        List<RayInteraction> interactions
+    ) {
+        if (interactions == null || interactions.isEmpty()) {
+            return List.of();
+        }
+        List<RayInteraction> publicJoins = new ArrayList<>(interactions.size());
+        for (RayInteraction interaction : interactions) {
+            if (isPublicJoinForTable(interaction, tableId)) {
+                publicJoins.add(interaction);
+            }
+        }
+        return publicJoins.isEmpty() ? List.of() : List.copyOf(publicJoins);
     }
 
     private static boolean isPublicJoinForTable(RayInteraction interaction, String tableId) {

--- a/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
@@ -62,6 +62,9 @@ final class SparrowRayInteractionProxyCoordinator {
         }
 
         Map<UUID, ActiveProxies> previous = this.regions.getOrDefault(regionKey, Map.of());
+        if (this.canReuseRegion(previous, interactionsByViewer)) {
+            return;
+        }
         Map<UUID, ActiveProxies> next = new LinkedHashMap<>();
         List<PendingSpawn> pendingSpawns = new ArrayList<>();
         try {
@@ -130,6 +133,31 @@ final class SparrowRayInteractionProxyCoordinator {
                 return;
             }
         }
+    }
+
+    private boolean canReuseRegion(
+        Map<UUID, ActiveProxies> previous,
+        Map<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> interactionsByViewer
+    ) {
+        int reusableViewers = 0;
+        for (Map.Entry<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> entry
+            : interactionsByViewer.entrySet()) {
+            UUID viewerId = entry.getKey();
+            List<DisplayInteractionRayRegistry.RayInteraction> interactions = entry.getValue();
+            if (viewerId == null || interactions == null || interactions.isEmpty()) {
+                continue;
+            }
+            Player viewer = this.session.onlinePlayer(viewerId);
+            if (viewer == null || !viewer.isOnline()) {
+                continue;
+            }
+            ActiveProxies active = previous.get(viewerId);
+            if (!this.canReuse(viewerId, viewer, active, interactions)) {
+                return false;
+            }
+            reusableViewers++;
+        }
+        return reusableViewers == previous.size();
     }
 
     private boolean canReuse(

--- a/src/test/java/top/ellan/mahjong/render/display/FlatDisplayInteractionRegistryTest.java
+++ b/src/test/java/top/ellan/mahjong/render/display/FlatDisplayInteractionRegistryTest.java
@@ -3,6 +3,7 @@ package top.ellan.mahjong.render.display;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
 import java.util.UUID;
@@ -130,6 +131,109 @@ final class DisplayInteractionRayRegistryTest {
         assertEquals(List.of(action, tile), DisplayInteractionRayRegistry.snapshot(VIEWER_ID));
         DisplayInteractionRayRegistry.clearRegion(VIEWER_ID, "table-a", "viewer-actions");
         assertEquals(List.of(tile), DisplayInteractionRayRegistry.snapshot(VIEWER_ID));
+    }
+
+    @Test
+    void identicalRegionReplacementKeepsTheExistingSnapshotAndActionChangesStillApply() {
+        DisplayInteractionRayRegistry.RayInteraction first = interaction(
+            0.0D,
+            3.0D,
+            1.0D,
+            0.0D,
+            action("first")
+        );
+        DisplayInteractionRayRegistry.replaceRegion(
+            VIEWER_ID,
+            "table-a",
+            "viewer-actions",
+            List.of(first)
+        );
+        List<DisplayInteractionRayRegistry.RayInteraction> firstSnapshot =
+            DisplayInteractionRayRegistry.snapshot(VIEWER_ID);
+
+        DisplayInteractionRayRegistry.replaceRegion(
+            VIEWER_ID,
+            "table-a",
+            "viewer-actions",
+            List.of(first)
+        );
+
+        assertSame(firstSnapshot, DisplayInteractionRayRegistry.snapshot(VIEWER_ID));
+
+        DisplayInteractionRayRegistry.RayInteraction changed = interaction(
+            0.0D,
+            3.0D,
+            1.0D,
+            0.0D,
+            action("second")
+        );
+        DisplayInteractionRayRegistry.replaceRegion(
+            VIEWER_ID,
+            "table-a",
+            "viewer-actions",
+            List.of(changed)
+        );
+
+        assertEquals(List.of(changed), DisplayInteractionRayRegistry.snapshot(VIEWER_ID));
+    }
+
+    @Test
+    void identicalPublicJoinReplacementKeepsTheExistingFlattenedSnapshot() {
+        DisplayInteractionRayRegistry.RayInteraction join = interaction(
+            0.0D,
+            3.0D,
+            1.0D,
+            0.0D,
+            DisplayClickAction.joinSeat("table-a", SeatWind.EAST)
+        );
+        DisplayInteractionRayRegistry.RayInteraction privateDecision = interaction(
+            0.0D,
+            4.0D,
+            1.0D,
+            0.0D,
+            action("private")
+        );
+        List<DisplayInteractionRayRegistry.RayInteraction> input = List.of(join, privateDecision);
+
+        DisplayInteractionRayRegistry.replacePublicJoinRegion("table-a", "seat-label:EAST", input);
+        List<DisplayInteractionRayRegistry.RayInteraction> firstSnapshot =
+            DisplayInteractionRayRegistry.publicJoinSnapshot();
+
+        DisplayInteractionRayRegistry.replacePublicJoinRegion("table-a", "seat-label:EAST", input);
+
+        assertSame(firstSnapshot, DisplayInteractionRayRegistry.publicJoinSnapshot());
+        assertEquals(List.of(join), firstSnapshot);
+    }
+
+    @Test
+    void replacingPublicJoinActionStillUpdatesTheFlattenedSnapshot() {
+        DisplayInteractionRayRegistry.RayInteraction east = interaction(
+            0.0D,
+            3.0D,
+            1.0D,
+            0.0D,
+            DisplayClickAction.joinSeat("table-a", SeatWind.EAST)
+        );
+        DisplayInteractionRayRegistry.RayInteraction south = interaction(
+            0.0D,
+            3.0D,
+            1.0D,
+            0.0D,
+            DisplayClickAction.joinSeat("table-a", SeatWind.SOUTH)
+        );
+
+        DisplayInteractionRayRegistry.replacePublicJoinRegion(
+            "table-a",
+            "seat-label:EAST",
+            List.of(east)
+        );
+        DisplayInteractionRayRegistry.replacePublicJoinRegion(
+            "table-a",
+            "seat-label:EAST",
+            List.of(south)
+        );
+
+        assertEquals(List.of(south), DisplayInteractionRayRegistry.publicJoinSnapshot());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a region-level fast path for unchanged Sparrow ray proxy ownership, online viewers, geometry, and proxy lifecycle state.
- Avoid rebuilding equivalent private ray snapshots and public JOIN snapshots; action changes and ownership loss still take the existing update/recovery paths.
- Add regression coverage for unchanged snapshots, action changes, and public JOIN filtering.

## Validation
- `./gradlew -PmahjongJavaTarget=21 test --console plain`
- `./gradlew -PmahjongJavaTarget=21 build --console plain`
- `./gradlew -PmahjongJavaTarget=21 perfTest --console plain`
- `./gradlew -PmahjongJavaTarget=17 jmhJar --console plain`
- RayProxyCoordinatorBenchmark production adapter smoke run passed its lifecycle contract.

## Scope
- No changes to Mahjong rules, visibility, seat logic, hit testing semantics, scheduler semantics, A/B thresholds, protected workflows, or benchmark sources.
- The change is intended to reduce repeated CPU/allocation and lifecycle bookkeeping; it does not claim speculative network-packet savings.