### PR TITLE
perf(render): route seat region keys through a string switch

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -1017,28 +1017,25 @@ public final class TableRegionDisplayCoordinator {
     }
 
     private String seatRegionKey(String region, SeatWind wind) {
-        if ("visual".equals(region)) {
-            return VISUAL_REGION_KEYS[wind.index()];
+        int index = wind.index();
+        switch (region) {
+            case "visual":
+                return VISUAL_REGION_KEYS[index];
+            case "labels":
+                return LABEL_REGION_KEYS[index];
+            case "sticks":
+                return STICK_REGION_KEYS[index];
+            case "hand-public":
+                return HAND_PUBLIC_REGION_KEYS[index];
+            case "hand-private":
+                return HAND_PRIVATE_REGION_KEYS[index];
+            case "discards":
+                return DISCARD_REGION_KEYS[index];
+            case "melds":
+                return MELD_REGION_KEYS[index];
+            default:
+                return region + ":" + wind.name();
         }
-        if ("labels".equals(region)) {
-            return LABEL_REGION_KEYS[wind.index()];
-        }
-        if ("sticks".equals(region)) {
-            return STICK_REGION_KEYS[wind.index()];
-        }
-        if ("hand-public".equals(region)) {
-            return HAND_PUBLIC_REGION_KEYS[wind.index()];
-        }
-        if ("hand-private".equals(region)) {
-            return HAND_PRIVATE_REGION_KEYS[wind.index()];
-        }
-        if ("discards".equals(region)) {
-            return DISCARD_REGION_KEYS[wind.index()];
-        }
-        if ("melds".equals(region)) {
-            return MELD_REGION_KEYS[wind.index()];
-        }
-        return region + ":" + wind.name();
     }
 
     private String handPrivateRegionKey(SeatWind wind, int tileIndex) {


### PR DESCRIPTION
## Summary

Optimize `TableRegionDisplayCoordinator.seatRegionKey` to reduce per-call dispatch overhead on the region key plan hot path.

## Changes

- Replace the linear `if`-`equals` chain with a `switch (region)` on the region string. The javac-emitted `lookupswitch` hashes the region once and dispatches in constant time, instead of performing up to seven `String.equals` checks.
- Hoist `wind.index()` into a local variable so every case reads the same array index without re-invoking the accessor.

## Behavior equivalence

All existing semantics are preserved:
- Each region name (`visual`, `labels`, `sticks`, `hand-public`, `hand-private`, `discards`, `melds`) still resolves to the same precomputed key array entry.
- The fallback path still concatenates `region + ":" + wind.name()` for unknown region names.
- No game rules or player-visible behavior change.

## Verification

Target the `region-keys` performance profile (`RegionKeyPlanBenchmark.buildRepresentativeRegionKeyPlan`).

Labels: `performance-ab`, `performance-region-keys`
