### PR TITLE
perf(render): skip runtime snapshot for singleton display spawns

### DIFF
--- a/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
+++ b/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
@@ -194,12 +194,13 @@ public final class DisplayEntities {
         if (runtime == null || runtime.bukkitPlugin() == null || specs == null || specs.isEmpty()) {
             return List.of();
         }
-        DisplayEntityRuntime scopedRuntime = visibilitySnapshotRuntime(runtime, true);
-        if (specs.size() == 1) {
-            Entity entity = specs.get(0).spawn(scopedRuntime);
+        int size = specs.size();
+        if (size == 1) {
+            Entity entity = specs.get(0).spawn(runtime);
             return entity == null ? List.of() : List.of(entity);
         }
-        List<Entity> spawned = new java.util.ArrayList<>(specs.size());
+        DisplayEntityRuntime scopedRuntime = visibilitySnapshotRuntime(runtime, true);
+        List<Entity> spawned = new java.util.ArrayList<>(size);
         for (EntitySpec spec : specs) {
             Entity entity = spec.spawn(scopedRuntime);
             if (entity != null) {


### PR DESCRIPTION
## Summary

Optimize `DisplayEntities.spawnAll` to skip the runtime snapshot wrapper on the singleton fast path.

## Changes

- When `specs.size() == 1`, pass the original `runtime` directly to `spec.spawn()` instead of wrapping it in `SnapshotDisplayEntityRuntime`. The singleton path performs only a single `spawn()` call, so the cross-spec visibility consistency that the wrapper provides is unobservable. This eliminates one wrapper allocation and one `List.copyOf(onlinePlayers)` call per singleton spawn.
- The multi-spec path still wraps the runtime with an eager snapshot to preserve cross-spec visibility consistency.
- Hoist `specs.size()` into a local variable so the empty check, singleton check, and `ArrayList` capacity all read the same value without re-invoking `size()`.

## Behavior equivalence

- Singleton path: `spec.spawn(runtime)` produces the same entity as `spec.spawn(scopedRuntime)` because the wrapper is a pure delegate (every method forwards to the original runtime). The only behavioral difference the wrapper provides is caching `onlinePlayers()` — which is irrelevant when only one spec reads it.
- Multi-spec path: unchanged.
- Null/empty handling: unchanged.

## Verification

Target the `display-spawn` performance profile (`DisplayEntitiesSpawnAllBenchmark.spawnRepresentativeTableRegions`).

Labels: `performance-ab`, `performance-display-spawn`
