### PR TITLE
perf(render): reuse fingerprint builder and precompute region keys

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -1,6 +1,8 @@
 package top.ellan.mahjong.table.render;
 
+import top.ellan.mahjong.model.MahjongTile;
 import top.ellan.mahjong.model.SeatWind;
+import top.ellan.mahjong.riichi.model.ScoringStick;
 import top.ellan.mahjong.render.TableRenderSubject;
 import top.ellan.mahjong.render.layout.TableRenderLayout;
 import top.ellan.mahjong.render.snapshot.TableRenderSnapshot;
@@ -15,18 +17,37 @@ public final class TableRegionFingerprintService {
     private static final String REGION_DORA = "dora";
     private static final String REGION_CENTER = "center";
 
+    private static final String[][] SEAT_REGION_KEYS = createSeatRegionKeys();
+    private static final int SEAT_KEY_VISUAL = 0;
+    private static final int SEAT_KEY_LABELS = 1;
+    private static final int SEAT_KEY_STICKS = 2;
+    private static final int SEAT_KEY_HAND_PUBLIC = 3;
+
+    private static String[][] createSeatRegionKeys() {
+        SeatWind[] winds = SeatWind.values();
+        String[][] keys = new String[4][winds.length];
+        String[] prefixes = {"visual", "labels", "sticks", "hand-public"};
+        for (int region = 0; region < prefixes.length; region++) {
+            for (SeatWind wind : winds) {
+                keys[region][wind.index()] = prefixes[region] + ":" + wind.name();
+            }
+        }
+        return keys;
+    }
+
     public Map<String, Long> precomputeRegionFingerprints(TableRenderSubject session, TableRenderSnapshot snapshot) {
-        Map<String, Long> fingerprints = new HashMap<>();
+        Map<String, Long> fingerprints = new HashMap<>(32);
         fingerprints.put(REGION_TABLE, this.tableFingerprint(session, snapshot));
         fingerprints.put(REGION_WALL, this.wallFingerprint(snapshot));
         fingerprints.put(REGION_DORA, this.doraFingerprint(snapshot));
         fingerprints.put(REGION_CENTER, this.centerFingerprint(snapshot));
         for (SeatWind wind : SeatWind.values()) {
+            int idx = wind.index();
             TableSeatRenderSnapshot seat = snapshot.seat(wind);
-            fingerprints.put(this.seatRegionKey("visual", wind), this.seatVisualFingerprint(session, wind));
-            fingerprints.put(this.seatRegionKey("labels", wind), this.seatLabelFingerprint(session, snapshot, seat));
-            fingerprints.put(this.seatRegionKey("sticks", wind), this.stickFingerprint(snapshot, seat));
-            fingerprints.put(this.seatRegionKey("hand-public", wind), this.handPublicFingerprint(snapshot, seat));
+            fingerprints.put(SEAT_REGION_KEYS[SEAT_KEY_VISUAL][idx], this.seatVisualFingerprint(session, wind));
+            fingerprints.put(SEAT_REGION_KEYS[SEAT_KEY_LABELS][idx], this.seatLabelFingerprint(session, snapshot, seat));
+            fingerprints.put(SEAT_REGION_KEYS[SEAT_KEY_STICKS][idx], this.stickFingerprint(snapshot, seat));
+            fingerprints.put(SEAT_REGION_KEYS[SEAT_KEY_HAND_PUBLIC][idx], this.handPublicFingerprint(snapshot, seat));
         }
         return Map.copyOf(fingerprints);
     }
@@ -154,7 +175,9 @@ public final class TableRegionFingerprintService {
             .field("dora")
             .field(snapshot.started())
             .field(snapshot.doraIndicators().size());
-        snapshot.doraIndicators().forEach(tile -> builder.field(tile.name()));
+        for (MahjongTile tile : snapshot.doraIndicators()) {
+            builder.field(tile.name());
+        }
         return builder.value();
     }
 
@@ -214,7 +237,9 @@ public final class TableRegionFingerprintService {
             .field(seat.online())
             .field(seat.viewerMembershipSignature())
             .field(seat.stickLayoutCount());
-        seat.hand().forEach(tile -> builder.field(tile.name()));
+        for (MahjongTile tile : seat.hand()) {
+            builder.field(tile.name());
+        }
         return builder.value();
     }
 
@@ -245,18 +270,23 @@ public final class TableRegionFingerprintService {
             return builder.value();
         }
         builder.field(seat.riichi());
-        seat.scoringSticks().forEach(stick -> builder.field(stick.name()));
-        seat.cornerSticks().forEach(stick -> builder.field(stick.name()));
+        for (ScoringStick stick : seat.scoringSticks()) {
+            builder.field(stick.name());
+        }
+        for (ScoringStick stick : seat.cornerSticks()) {
+            builder.field(stick.name());
+        }
         return builder.value();
     }
 
-    private String seatRegionKey(String region, SeatWind wind) {
-        return region + ":" + wind.name();
+    private static FingerprintBuilder fingerprintBuilder(int capacity) {
+        FingerprintBuilder builder = BUILDER_CACHE.get();
+        builder.reset();
+        return builder;
     }
 
-    private static FingerprintBuilder fingerprintBuilder(int capacity) {
-        return new FingerprintBuilder();
-    }
+    private static final ThreadLocal<FingerprintBuilder> BUILDER_CACHE =
+        ThreadLocal.withInitial(FingerprintBuilder::new);
 
     private static final class FingerprintBuilder {
         private static final long FNV_OFFSET_BASIS = 0xcbf29ce484222325L;
@@ -264,6 +294,11 @@ public final class TableRegionFingerprintService {
 
         private long hash = FNV_OFFSET_BASIS;
         private boolean needsSeparator;
+
+        private void reset() {
+            this.hash = FNV_OFFSET_BASIS;
+            this.needsSeparator = false;
+        }
 
         private FingerprintBuilder field(Object value) {
             this.startField('o');


### PR DESCRIPTION
## Summary

Reduce allocation pressure in `TableRegionFingerprintService` across four independent optimizations targeting both the `precomputeStartedTableRegions` and `fingerprintRenderedTileBatch` benchmarks.

## Changes

1. **ThreadLocal FingerprintBuilder** — The per-tile fingerprint path allocates a new `FingerprintBuilder` for each of the ~312 tiles in a rendered batch, and the per-region path allocates ~20 more. Replace `new FingerprintBuilder()` with a ThreadLocal-cached instance that is `reset()` before each use. This eliminates hundreds of short-lived allocations per fingerprint pass.

2. **forEach lambda → enhanced for loop** — `doraIndicators`, `hand`, `scoringSticks`, and `cornerSticks` each captured the builder in a lambda passed to `forEach`, allocating a `Consumer` per call. Switch to enhanced for loops so no lambda object is created.

3. **Precompute seat region keys** — `seatRegionKey` performed string concatenation 16 times per `precompute` call for a fixed set of region+wind combinations. Precompute all keys into a static 4×4 array at class init and index by wind, removing 16 StringBuilder + String allocations per call.

4. **HashMap initial capacity** — `precomputeRegionFingerprints` stores 20 entries but used the default capacity of 16 (threshold 12), forcing a resize. Pre-size to 32 (threshold 24) so no resize occurs.

## Behavior equivalence

- FNV hash logic, field order, type tags (`'o'/'u'/'b'/'i'/'l'`), separator characters (`:`), and the immutable `Map.copyOf` return value are all preserved.
- The ThreadLocal builder is safe because render precompute runs on a dedicated thread — no nested or concurrent `fingerprintBuilder()` calls.
- The `capacity` argument to `fingerprintBuilder` is now unused but retained to avoid touching every call site.

## Verification

Target the `region-fingerprint` performance profile (`TableRegionFingerprintBenchmark.precomputeStartedTableRegions` and `fingerprintRenderedTileBatch`).

Labels: `performance-ab`, `performance-region-fingerprint`
