### PR TITLE
perf(gb-bot): reuse working list in bestDiscardChoice

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -192,14 +192,19 @@ final class GbBotDecisionService {
         GbTingResponse[] tingMemo = new GbTingResponse[TILE_KIND_COUNT];
         MahjongTile previousDiscarded = null;
         int previousDiscardPreference = 0;
+        List<MahjongTile> remaining = new ArrayList<>(hand.size() - 1);
         for (int i = 0; i < hand.size(); i++) {
             MahjongTile discarded = hand.get(i);
             int discardedOrdinal = discarded.ordinal();
             GbTingResponse ting = tingMemo[discardedOrdinal];
             boolean tingMemoHit = ting != null;
             if (ting == null) {
-                List<MahjongTile> remaining = new ArrayList<>(hand);
-                remaining.remove(i);
+                remaining.clear();
+                for (int j = 0; j < hand.size(); j++) {
+                    if (j != i) {
+                        remaining.add(hand.get(j));
+                    }
+                }
                 ting = tingEvaluator.evaluate(remaining, melds);
                 if (ting != null) {
                     tingMemo[discardedOrdinal] = ting;


### PR DESCRIPTION
## Summary

Reduce allocation pressure in `GbBotDecisionService.bestDiscardChoice` by reusing the working `remaining` list across loop iterations.

## Changes

- Hoist a single `ArrayList<MahjongTile>` out of the `bestDiscardChoice` loop. Previously, every unique tile in the hand allocated a new `ArrayList<>(hand)` and called `remove(i)`, producing one ArrayList plus one internal `Object[]` per unique tile. For a 14-tile hand with all unique tiles, that is 14 ArrayList allocations and 14 array copies per call.
- On each iteration, `clear()` the working list and refill it with `add()` (skipping index `i`). The list is consumed synchronously by `tingEvaluator.evaluate()`, which reads the hand contents without retaining the reference, so reuse is safe.

## Behavior equivalence

- The `remaining` list has the same elements in the same order as before (all hand tiles except the one at index `i`).
- The ting memo, discard preference, and best-choice comparison logic are untouched.
- `tingEvaluator.evaluate()` does not retain the list reference — it reads tile contents and returns a `GbTingResponse`, so the next iteration's `clear()` is safe.

## Verification

Target the `gb-bot` performance profile (`GbBotDecisionBenchmark.duplicateHand`, `mixedHand`, `uniqueHand`).

Labels: `performance-ab`, `performance-gb-bot`
