### PR TITLE
perf(render): bypass synthetic accessors in applyQueue

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -476,8 +476,9 @@ public final class TableRegionDisplayCoordinator {
 
     private QueueExecution applyQueue(RegionUpdateQueue updates) {
         int processed = 0;
-        for (int bucketIndex = 0; bucketIndex < updates.bucketCount(); bucketIndex++) {
-            List<RegionUpdateAction> bucket = updates.bucket(bucketIndex);
+        List<RegionUpdateAction>[] buckets = updates.buckets;
+        for (int bucketIndex = 0; bucketIndex < buckets.length; bucketIndex++) {
+            List<RegionUpdateAction> bucket = buckets[bucketIndex];
             for (int updateIndex = 0, bucketSize = bucket.size(); updateIndex < bucketSize; updateIndex++) {
                 if (!bucket.get(updateIndex).apply()) {
                     return new QueueExecution(true, processed);


### PR DESCRIPTION
## Summary

Bypass synthetic accessor methods in `TableRegionDisplayCoordinator.applyQueue` by reading the `RegionUpdateQueue.buckets` array field directly.

## Changes

- `applyQueue` previously called `updates.bucketCount()` and `updates.bucket(bucketIndex)`, which are synthetic accessor methods generated by javac for private-inner-class field access. Read `updates.buckets` directly instead, eliminating two synthetic method calls per queue application.

## Behavior equivalence

- Iteration order, early-return on deferred action, and `QueueExecution` result are all identical.
- `RegionUpdateQueue` is a private inner class of the same top-level class, so the `buckets` field is reachable without accessors.

## Verification

Target the `region-queue` performance profile (`RegionUpdateQueueBenchmark.orderRepresentativeTableRegions`).

Labels: `performance-ab`, `performance-region-queue`
