### PR TITLE
perf(runtime): cache Folia global and region scheduler instances

### DIFF
--- a/src/main/java/top/ellan/mahjong/runtime/ServerScheduler.java
+++ b/src/main/java/top/ellan/mahjong/runtime/ServerScheduler.java
@@ -90,6 +90,8 @@ public final class ServerScheduler {
     };
 
     private final Plugin plugin;
+    private volatile Object cachedGlobalRegionScheduler;
+    private volatile Object cachedRegionScheduler;
 
     public ServerScheduler(Plugin plugin) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
@@ -313,11 +315,27 @@ public final class ServerScheduler {
     }
 
     private Object globalRegionScheduler() {
-        return this.invokeNoArgs(this.plugin.getServer(), GET_GLOBAL_REGION_SCHEDULER);
+        Object cached = this.cachedGlobalRegionScheduler;
+        if (cached != null) {
+            return cached;
+        }
+        Object resolved = this.invokeNoArgs(this.plugin.getServer(), GET_GLOBAL_REGION_SCHEDULER);
+        if (resolved != null) {
+            this.cachedGlobalRegionScheduler = resolved;
+        }
+        return resolved;
     }
 
     private Object regionScheduler() {
-        return this.invokeNoArgs(this.plugin.getServer(), GET_REGION_SCHEDULER);
+        Object cached = this.cachedRegionScheduler;
+        if (cached != null) {
+            return cached;
+        }
+        Object resolved = this.invokeNoArgs(this.plugin.getServer(), GET_REGION_SCHEDULER);
+        if (resolved != null) {
+            this.cachedRegionScheduler = resolved;
+        }
+        return resolved;
     }
 
     private Object entityScheduler(Entity entity) {


### PR DESCRIPTION
## Summary

Cache the Folia `GlobalRegionScheduler` and `RegionScheduler` instances to avoid repeated reflective lookups on every scheduling call.

## Changes

- Add `volatile` fields `cachedGlobalRegionScheduler` and `cachedRegionScheduler` to `ServerScheduler`.
- `globalRegionScheduler()` and `regionScheduler()` check the cache first; on a hit, return the cached instance directly, skipping `invokeNoArgs` (reflective method resolution + invocation). On the first successful non-null resolution, store the result in the cache.
- Null results (Paper server without Folia APIs) are never cached, so the existing fallback-to-BukkitScheduler behavior is preserved — the lookup still runs each time on Paper.
- `entityScheduler(Entity)` is not cached because the target entity varies per call.

## Behavior equivalence

- On Folia: the scheduler instances are stable singletons for the lifetime of the server, so caching is safe. The first call resolves reflectively; all subsequent calls return the same instance.
- On Paper: `getGlobalRegionScheduler()` / `getRegionScheduler()` do not exist, `invokeNoArgs` returns null, the cache stays empty, and the code falls back to `BukkitScheduler.runTask` exactly as before.
- No game rules or player-visible behavior change.

## Verification

Target the `scheduler-reflection` performance profile (`ServerSchedulerReflectionBenchmark.scheduleFoliaBurst` and `schedulePaperBurst`).

Labels: `performance-ab`, `performance-scheduler-reflection`
