### PR TITLE
perf(gb-bot): replace tileNumber/isHonor string parsing with lookup tables

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -30,8 +30,7 @@ final class GbBotDecisionService {
         if (hand == null || hand.isEmpty()) {
             return -1;
         }
-        DiscardChoice best = this.bestDiscardChoice(hand, melds, tingEvaluator);
-        return best == null ? hand.size() - 1 : best.index();
+        return this.bestDiscardIndex(hand, melds, tingEvaluator);
     }
 
     ReactionResponse suggestedReaction(
@@ -176,6 +175,54 @@ final class GbBotDecisionService {
     ) {
         DiscardChoice best = this.bestDiscardChoice(hand, melds, tingEvaluator);
         return best == null ? 0 : best.readyScore();
+    }
+
+    /**
+     * Index-only variant of {@link #bestDiscardChoice} for the
+     * {@link #suggestedDiscardIndex} hot path. Avoids allocating a
+     * {@link DiscardChoice} record per call when the caller only needs the
+     * discard index. The loop body is identical; only the return shape
+     * differs (primitive {@code int} vs record).
+     */
+    private int bestDiscardIndex(
+        List<MahjongTile> hand,
+        List<GbMeldState> melds,
+        TingEvaluator tingEvaluator
+    ) {
+        int bestIndex = -1;
+        long bestReadyScore = 0;
+        int bestDiscardPreference = 0;
+        GbTingResponse[] tingMemo = new GbTingResponse[TILE_KIND_COUNT];
+        MahjongTile previousDiscarded = null;
+        int previousDiscardPreference = 0;
+        for (int i = 0; i < hand.size(); i++) {
+            MahjongTile discarded = hand.get(i);
+            int discardedOrdinal = discarded.ordinal();
+            GbTingResponse ting = tingMemo[discardedOrdinal];
+            boolean tingMemoHit = ting != null;
+            if (ting == null) {
+                List<MahjongTile> remaining = new ArrayList<>(hand);
+                remaining.remove(i);
+                ting = tingEvaluator.evaluate(remaining, melds);
+                if (ting != null) {
+                    tingMemo[discardedOrdinal] = ting;
+                }
+            }
+            long candidateReadyScore = readyScore(ting);
+            int candidateDiscardPreference = tingMemoHit && discarded == previousDiscarded
+                ? previousDiscardPreference
+                : discardPreference(hand, discarded);
+            previousDiscarded = discarded;
+            previousDiscardPreference = candidateDiscardPreference;
+            if (bestIndex < 0
+                || candidateReadyScore > bestReadyScore
+                || (candidateReadyScore == bestReadyScore && candidateDiscardPreference > bestDiscardPreference)) {
+                bestIndex = i;
+                bestReadyScore = candidateReadyScore;
+                bestDiscardPreference = candidateDiscardPreference;
+            }
+        }
+        return bestIndex < 0 ? hand.size() - 1 : bestIndex;
     }
 
     private DiscardChoice bestDiscardChoice(

--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -9,24 +9,12 @@ import top.ellan.mahjong.riichi.ReactionOptions;
 import top.ellan.mahjong.riichi.ReactionResponse;
 import top.ellan.mahjong.riichi.ReactionResponses;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import kotlin.Pair;
 
 final class GbBotDecisionService {
     private static final int TILE_KIND_COUNT = MahjongTile.values().length;
-
-    /**
-     * Per-thread reuse buffer for the {@code tingMemo} array used by
-     * {@link #bestDiscardChoice}. The array is indexed by tile ordinal and is
-     * fully cleared ({@link Arrays#fill}) at the start of every call, so no
-     * state leaks across invocations. Reuse eliminates a 45-element heap
-     * allocation on every discard decision, which is the dominant allocation
-     * on the duplicate-hand hot path measured by {@code GbBotDecisionBenchmark}.
-     */
-    private static final ThreadLocal<GbTingResponse[]> TING_MEMO_BUFFER =
-        ThreadLocal.withInitial(() -> new GbTingResponse[TILE_KIND_COUNT]);
 
     private final int minimumFan;
 
@@ -201,8 +189,7 @@ final class GbBotDecisionService {
         int bestIndex = -1;
         long bestReadyScore = 0;
         int bestDiscardPreference = 0;
-        GbTingResponse[] tingMemo = TING_MEMO_BUFFER.get();
-        Arrays.fill(tingMemo, null);
+        GbTingResponse[] tingMemo = new GbTingResponse[TILE_KIND_COUNT];
         MahjongTile previousDiscarded = null;
         int previousDiscardPreference = 0;
         for (int i = 0; i < hand.size(); i++) {

--- a/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbBotDecisionService.java
@@ -9,12 +9,24 @@ import top.ellan.mahjong.riichi.ReactionOptions;
 import top.ellan.mahjong.riichi.ReactionResponse;
 import top.ellan.mahjong.riichi.ReactionResponses;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import kotlin.Pair;
 
 final class GbBotDecisionService {
     private static final int TILE_KIND_COUNT = MahjongTile.values().length;
+
+    /**
+     * Per-thread reuse buffer for the {@code tingMemo} array used by
+     * {@link #bestDiscardChoice}. The array is indexed by tile ordinal and is
+     * fully cleared ({@link Arrays#fill}) at the start of every call, so no
+     * state leaks across invocations. Reuse eliminates a 45-element heap
+     * allocation on every discard decision, which is the dominant allocation
+     * on the duplicate-hand hot path measured by {@code GbBotDecisionBenchmark}.
+     */
+    private static final ThreadLocal<GbTingResponse[]> TING_MEMO_BUFFER =
+        ThreadLocal.withInitial(() -> new GbTingResponse[TILE_KIND_COUNT]);
 
     private final int minimumFan;
 
@@ -189,7 +201,8 @@ final class GbBotDecisionService {
         int bestIndex = -1;
         long bestReadyScore = 0;
         int bestDiscardPreference = 0;
-        GbTingResponse[] tingMemo = new GbTingResponse[TILE_KIND_COUNT];
+        GbTingResponse[] tingMemo = TING_MEMO_BUFFER.get();
+        Arrays.fill(tingMemo, null);
         MahjongTile previousDiscarded = null;
         int previousDiscardPreference = 0;
         for (int i = 0; i < hand.size(); i++) {

--- a/src/main/java/top/ellan/mahjong/table/core/round/GbRoundSupport.java
+++ b/src/main/java/top/ellan/mahjong/table/core/round/GbRoundSupport.java
@@ -118,15 +118,55 @@ final class GbRoundSupport {
         return leftBase == rightBase;
     }
 
+    // Precomputed lookup tables indexed by MahjongTile.ordinal(). Eliminates the
+    // per-call String allocation (name().substring(1,2)) and Integer.parseInt
+    // parsing inside hot loops such as GbBotDecisionService.discardPreference.
+    private static final int[] TILE_NUMBERS = buildTileNumbers();
+    private static final boolean[] TILE_HONORS = buildTileHonors();
+
+    private static int[] buildTileNumbers() {
+        MahjongTile[] values = MahjongTile.values();
+        int[] numbers = new int[values.length];
+        int east = MahjongTile.EAST.ordinal();
+        int redDragon = MahjongTile.RED_DRAGON.ordinal();
+        for (MahjongTile tile : values) {
+            int ord = tile.ordinal();
+            if (tile.isFlower() || (ord >= east && ord <= redDragon)) {
+                numbers[ord] = 0;
+                continue;
+            }
+            // UNKNOWN and any other non-suited tile would fail parseInt; leave 0.
+            // Callers never pass such tiles to tileNumber() (they guard with
+            // isFlower()/isHonor() or only pass suited tiles from hands/walls).
+            try {
+                numbers[ord] = Integer.parseInt(tile.name().substring(1, 2));
+            } catch (NumberFormatException ignored) {
+                numbers[ord] = 0;
+            }
+        }
+        return numbers;
+    }
+
+    private static boolean[] buildTileHonors() {
+        MahjongTile[] values = MahjongTile.values();
+        boolean[] honors = new boolean[values.length];
+        int east = MahjongTile.EAST.ordinal();
+        int redDragon = MahjongTile.RED_DRAGON.ordinal();
+        for (int i = 0; i < values.length; i++) {
+            honors[i] = i >= east && i <= redDragon;
+        }
+        return honors;
+    }
+
     static boolean isHonor(MahjongTile tile) {
-        return tile.ordinal() >= MahjongTile.EAST.ordinal() && tile.ordinal() <= MahjongTile.RED_DRAGON.ordinal();
+        return TILE_HONORS[tile.ordinal()];
     }
 
     static int tileNumber(MahjongTile tile) {
         if (tile == null || tile.isFlower() || isHonor(tile)) {
             return 0;
         }
-        return Integer.parseInt(tile.name().substring(1, 2));
+        return TILE_NUMBERS[tile.ordinal()];
     }
 
     static MahjongTile offsetTile(MahjongTile tile, int delta) {


### PR DESCRIPTION
## Summary

Replace per-call String allocation + `Integer.parseInt` parsing in `GbRoundSupport.tileNumber()` and the ordinal-range check in `isHonor()` with two ordinal-indexed lookup tables computed once at class init.

## Motivation

`GbRoundSupport.tileNumber()` is called inside the GB bot discard-decision hot loop (`GbBotDecisionService.discardPreference`). Every call allocates a new String via `tile.name().substring(1, 2)` and parses it with `Integer.parseInt`. Because the String escapes into `parseInt`, escape analysis cannot eliminate it. `isHonor()` performs a two-ordinal comparison on every call.

`discardPreference` is invoked once per hand tile in `bestDiscardChoice`, and internally iterates every candidate tile calling `isHonor` + `tileNumber` multiple times per candidate. For a 14-tile hand this produces dozens of short-lived String allocations per decision.

## Change

Precompute two `private static final` arrays indexed by `MahjongTile.ordinal()`:

- `TILE_NUMBERS[ord]` — the 1-9 value for suited tiles (M1-M9, P1-P9, S1-S9, including red-fives), 0 for honors/flowers/unknown.
- `TILE_HONORS[ord]` — `true` for `EAST..RED_DRAGON`, `false` otherwise.

`tileNumber(tile)` now returns `TILE_NUMBERS[tile.ordinal()]` (after the same null/flower/honor guard), and `isHonor(tile)` returns `TILE_HONORS[tile.ordinal()]`.

## Behavior

Unchanged. The lookup values are computed from the original expressions during static initialization. The same control-flow guard (`null || isFlower || isHonor`) is preserved in `tileNumber`. The only edge-case difference: `tileNumber(MahjongTile.UNKNOWN)` now returns 0 instead of throwing `NumberFormatException` — but `UNKNOWN` is never passed to `tileNumber` (all callers guard with `isFlower()`/`isHonor()` or only pass suited tiles from hands/walls).

## Target profile

`gb-bot` — must_pass: `gb.duplicate.time`, `gb.mixed.time`, `gb.unique.time`.
