### PR TITLE
perf(render): cache stable ray proxy identities

### DIFF
--- a/src/main/java/top/ellan/mahjong/render/display/ClientInteractionProxyRegistry.java
+++ b/src/main/java/top/ellan/mahjong/render/display/ClientInteractionProxyRegistry.java
@@ -26,14 +26,6 @@ public final class ClientInteractionProxyRegistry {
         return owner != null && viewerId.equals(owner.viewerId()) ? owner.tableId() : null;
     }
 
-    public static boolean isOwnedBy(int entityId, UUID viewerId, String tableId) {
-        if (viewerId == null || tableId == null) {
-            return false;
-        }
-        ProxyOwner owner = OWNERS.get(entityId);
-        return owner != null && owner.matches(viewerId, tableId);
-    }
-
     public static void unregister(int entityId, UUID viewerId, String tableId) {
         if (viewerId == null || tableId == null) {
             return;
@@ -73,8 +65,5 @@ public final class ClientInteractionProxyRegistry {
     }
 
     private record ProxyOwner(UUID viewerId, String tableId) {
-        private boolean matches(UUID expectedViewerId, String expectedTableId) {
-            return expectedViewerId.equals(this.viewerId) && expectedTableId.equals(this.tableId);
-        }
     }
 }

--- a/src/main/java/top/ellan/mahjong/render/display/ClientInteractionProxyRegistry.java
+++ b/src/main/java/top/ellan/mahjong/render/display/ClientInteractionProxyRegistry.java
@@ -26,6 +26,14 @@ public final class ClientInteractionProxyRegistry {
         return owner != null && viewerId.equals(owner.viewerId()) ? owner.tableId() : null;
     }
 
+    public static boolean isOwnedBy(int entityId, UUID viewerId, String tableId) {
+        if (viewerId == null || tableId == null) {
+            return false;
+        }
+        ProxyOwner owner = OWNERS.get(entityId);
+        return owner != null && owner.matches(viewerId, tableId);
+    }
+
     public static void unregister(int entityId, UUID viewerId, String tableId) {
         if (viewerId == null || tableId == null) {
             return;
@@ -65,5 +73,8 @@ public final class ClientInteractionProxyRegistry {
     }
 
     private record ProxyOwner(UUID viewerId, String tableId) {
+        private boolean matches(UUID expectedViewerId, String expectedTableId) {
+            return expectedViewerId.equals(this.viewerId) && expectedTableId.equals(this.tableId);
+        }
     }
 }

--- a/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
@@ -36,11 +36,9 @@ final class SparrowRayInteractionProxyCoordinator {
     private static final Backend DEFAULT_BACKEND = new SparrowBackend();
 
     private final TableSessionContext session;
-    private final String tableId;
     private final Backend backend;
     private final Map<String, Map<UUID, ActiveProxies>> regions = new LinkedHashMap<>();
     private final AtomicBoolean warningLogged = new AtomicBoolean();
-    private int entityCount;
 
     SparrowRayInteractionProxyCoordinator(TableSessionContext session) {
         this(session, DEFAULT_BACKEND);
@@ -48,7 +46,6 @@ final class SparrowRayInteractionProxyCoordinator {
 
     SparrowRayInteractionProxyCoordinator(TableSessionContext session, Backend backend) {
         this.session = session;
-        this.tableId = session == null ? null : session.id();
         this.backend = backend;
     }
 
@@ -90,14 +87,9 @@ final class SparrowRayInteractionProxyCoordinator {
                     continue;
                 }
                 List<InteractionGeometry> geometry = interactionGeometry(interactions);
-                List<ClientProxy> proxies = List.copyOf(this.backend.create(viewer, interactions));
+                List<ClientProxy> proxies = this.backend.create(viewer, interactions);
                 if (!proxies.isEmpty()) {
-                    ActiveProxies created = new ActiveProxies(
-                        viewer,
-                        proxies,
-                        geometry,
-                        proxies.get(0).entityId()
-                    );
+                    ActiveProxies created = new ActiveProxies(viewer, List.copyOf(proxies), geometry);
                     next.put(viewerId, created);
                     pendingSpawns.add(new PendingSpawn(viewerId, created));
                 }
@@ -114,21 +106,18 @@ final class SparrowRayInteractionProxyCoordinator {
                 this.removeActive(viewerId, active);
             }
         });
-        int previousCount = proxyCount(previous);
         if (next.isEmpty()) {
             this.regions.remove(regionKey);
-            this.entityCount -= previousCount;
             return;
         }
 
         Map<UUID, ActiveProxies> immutableNext = Map.copyOf(next);
         this.regions.put(regionKey, immutableNext);
-        this.entityCount += proxyCount(immutableNext) - previousCount;
         for (PendingSpawn pending : pendingSpawns) {
             UUID viewerId = pending.viewerId();
             ActiveProxies active = pending.active();
-            for (int index = 0; index < active.proxies().size(); index++) {
-                ClientInteractionProxyRegistry.register(active.entityId(index), viewerId, this.tableId);
+            for (ClientProxy proxy : active.proxies()) {
+                ClientInteractionProxyRegistry.register(proxy.entityId(), viewerId, this.session.id());
             }
             try {
                 this.session.runForViewer(
@@ -172,15 +161,15 @@ final class SparrowRayInteractionProxyCoordinator {
         ActiveProxies active,
         List<DisplayInteractionRayRegistry.RayInteraction> interactions
     ) {
-        if (active == null || active.proxies().isEmpty() || !sameGeometry(active.geometry(), interactions)) {
+        if (active == null
+            || !sameGeometry(active.geometry(), interactions)
+            || active.proxies().isEmpty()) {
             return false;
         }
-        return this.hasOwnership(viewerId, active);
-    }
-
-    private boolean hasOwnership(UUID viewerId, ActiveProxies active) {
-        for (int index = 0; index < active.proxies().size(); index++) {
-            if (!ClientInteractionProxyRegistry.isOwnedBy(active.entityId(index), viewerId, this.tableId)) {
+        for (ClientProxy proxy : active.proxies()) {
+            if (!this.session.id().equals(
+                ClientInteractionProxyRegistry.tableIdFor(proxy.entityId(), viewerId)
+            )) {
                 return false;
             }
         }
@@ -233,8 +222,15 @@ final class SparrowRayInteractionProxyCoordinator {
                 continue;
             }
             ActiveProxies active = activeByViewer == null ? null : activeByViewer.get(ownerId);
-            if (active == null || active.proxies().isEmpty() || !this.hasOwnership(ownerId, active)) {
+            if (active == null || active.proxies().isEmpty()) {
                 return false;
+            }
+            for (ClientProxy proxy : active.proxies()) {
+                if (!this.session.id().equals(
+                    ClientInteractionProxyRegistry.tableIdFor(proxy.entityId(), ownerId)
+                )) {
+                    return false;
+                }
             }
         }
         return true;
@@ -245,7 +241,6 @@ final class SparrowRayInteractionProxyCoordinator {
         if (removed == null) {
             return;
         }
-        this.entityCount -= proxyCount(removed);
         removed.forEach(this::removeActive);
     }
 
@@ -265,7 +260,6 @@ final class SparrowRayInteractionProxyCoordinator {
             } else {
                 this.regions.put(regionKey, Map.copyOf(remaining));
             }
-            this.entityCount -= removed.proxies().size();
             this.removeActive(viewerId, removed);
         }
     }
@@ -274,15 +268,13 @@ final class SparrowRayInteractionProxyCoordinator {
         for (String regionKey : List.copyOf(this.regions.keySet())) {
             this.remove(regionKey);
         }
-        this.entityCount = 0;
-        ClientInteractionProxyRegistry.clearTable(this.tableId);
+        ClientInteractionProxyRegistry.clearTable(this.session.id());
     }
 
     synchronized void shutdown() {
         Map<String, Map<UUID, ActiveProxies>> activeRegions = Map.copyOf(this.regions);
         this.regions.clear();
-        this.entityCount = 0;
-        ClientInteractionProxyRegistry.clearTable(this.tableId);
+        ClientInteractionProxyRegistry.clearTable(this.session.id());
         activeRegions.values().forEach(activeByViewer -> activeByViewer.forEach((viewerId, active) -> {
             if (active.viewer().isOnline()) {
                 this.destroyQuietly(active.viewer(), active.proxies());
@@ -291,13 +283,11 @@ final class SparrowRayInteractionProxyCoordinator {
     }
 
     synchronized int entityCount() {
-        return this.entityCount;
-    }
-
-    private static int proxyCount(Map<UUID, ActiveProxies> activeByViewer) {
         int count = 0;
-        for (ActiveProxies active : activeByViewer.values()) {
-            count += active.proxies().size();
+        for (Map<UUID, ActiveProxies> activeByViewer : this.regions.values()) {
+            for (ActiveProxies active : activeByViewer.values()) {
+                count += active.proxies().size();
+            }
         }
         return count;
     }
@@ -322,14 +312,14 @@ final class SparrowRayInteractionProxyCoordinator {
         }
     }
 
-    private void unregister(UUID viewerId, ActiveProxies active) {
-        for (int index = 0; index < active.proxies().size(); index++) {
-            ClientInteractionProxyRegistry.unregister(active.entityId(index), viewerId, this.tableId);
+    private void unregister(UUID viewerId, List<ClientProxy> proxies) {
+        for (ClientProxy proxy : proxies) {
+            ClientInteractionProxyRegistry.unregister(proxy.entityId(), viewerId, this.session.id());
         }
     }
 
     private void removeActive(UUID viewerId, ActiveProxies active) {
-        this.unregister(viewerId, active);
+        this.unregister(viewerId, active.proxies());
         if (!active.viewer().isOnline()) {
             return;
         }
@@ -385,12 +375,8 @@ final class SparrowRayInteractionProxyCoordinator {
     private record ActiveProxies(
         Player viewer,
         List<ClientProxy> proxies,
-        List<InteractionGeometry> geometry,
-        int firstEntityId
+        List<InteractionGeometry> geometry
     ) {
-        private int entityId(int index) {
-            return index == 0 ? this.firstEntityId : this.proxies.get(index).entityId();
-        }
     }
 
     private record PendingSpawn(UUID viewerId, ActiveProxies active) {

--- a/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
@@ -36,9 +36,11 @@ final class SparrowRayInteractionProxyCoordinator {
     private static final Backend DEFAULT_BACKEND = new SparrowBackend();
 
     private final TableSessionContext session;
+    private final String tableId;
     private final Backend backend;
     private final Map<String, Map<UUID, ActiveProxies>> regions = new LinkedHashMap<>();
     private final AtomicBoolean warningLogged = new AtomicBoolean();
+    private int entityCount;
 
     SparrowRayInteractionProxyCoordinator(TableSessionContext session) {
         this(session, DEFAULT_BACKEND);
@@ -46,6 +48,7 @@ final class SparrowRayInteractionProxyCoordinator {
 
     SparrowRayInteractionProxyCoordinator(TableSessionContext session, Backend backend) {
         this.session = session;
+        this.tableId = session == null ? null : session.id();
         this.backend = backend;
     }
 
@@ -84,13 +87,16 @@ final class SparrowRayInteractionProxyCoordinator {
                     next.put(viewerId, current);
                     continue;
                 }
-                List<InteractionGeometry> geometry = interactionGeometry(interactions);
-                List<ClientProxy> proxies = this.backend.create(viewer, interactions);
+                List<DisplayInteractionRayRegistry.RayInteraction> stableInteractions = List.copyOf(interactions);
+                List<InteractionGeometry> geometry = interactionGeometry(stableInteractions);
+                List<ClientProxy> proxies = List.copyOf(this.backend.create(viewer, stableInteractions));
                 if (!proxies.isEmpty()) {
                     ActiveProxies created = new ActiveProxies(
                         viewer,
-                        List.copyOf(proxies),
-                        geometry
+                        proxies,
+                        stableInteractions,
+                        geometry,
+                        proxies.get(0).entityId()
                     );
                     next.put(viewerId, created);
                     pendingSpawns.add(new PendingSpawn(viewerId, created));
@@ -108,18 +114,21 @@ final class SparrowRayInteractionProxyCoordinator {
                 this.removeActive(viewerId, active);
             }
         });
+        int previousCount = proxyCount(previous);
         if (next.isEmpty()) {
             this.regions.remove(regionKey);
+            this.entityCount -= previousCount;
             return;
         }
 
         Map<UUID, ActiveProxies> immutableNext = Map.copyOf(next);
         this.regions.put(regionKey, immutableNext);
+        this.entityCount += proxyCount(immutableNext) - previousCount;
         for (PendingSpawn pending : pendingSpawns) {
             UUID viewerId = pending.viewerId();
             ActiveProxies active = pending.active();
-            for (ClientProxy proxy : active.proxies()) {
-                ClientInteractionProxyRegistry.register(proxy.entityId(), viewerId, this.session.id());
+            for (int index = 0; index < active.proxies().size(); index++) {
+                ClientInteractionProxyRegistry.register(active.entityId(index), viewerId, this.tableId);
             }
             try {
                 this.session.runForViewer(
@@ -166,16 +175,18 @@ final class SparrowRayInteractionProxyCoordinator {
         ActiveProxies active,
         List<DisplayInteractionRayRegistry.RayInteraction> interactions
     ) {
-        if (active == null
-            || active.viewer() != viewer
-            || !sameGeometry(active.geometry(), interactions)
-            || active.proxies().isEmpty()) {
+        if (active == null || active.viewer() != viewer || active.proxies().isEmpty()) {
             return false;
         }
-        for (ClientProxy proxy : active.proxies()) {
-            if (!this.session.id().equals(
-                ClientInteractionProxyRegistry.tableIdFor(proxy.entityId(), viewerId)
-            )) {
+        if (active.interactions() != interactions && !sameGeometry(active.geometry(), interactions)) {
+            return false;
+        }
+        return this.hasOwnership(viewerId, active);
+    }
+
+    private boolean hasOwnership(UUID viewerId, ActiveProxies active) {
+        for (int index = 0; index < active.proxies().size(); index++) {
+            if (!ClientInteractionProxyRegistry.isOwnedBy(active.entityId(index), viewerId, this.tableId)) {
                 return false;
             }
         }
@@ -228,15 +239,8 @@ final class SparrowRayInteractionProxyCoordinator {
                 continue;
             }
             ActiveProxies active = activeByViewer == null ? null : activeByViewer.get(ownerId);
-            if (active == null || active.proxies().isEmpty()) {
+            if (active == null || active.proxies().isEmpty() || !this.hasOwnership(ownerId, active)) {
                 return false;
-            }
-            for (ClientProxy proxy : active.proxies()) {
-                if (!this.session.id().equals(
-                    ClientInteractionProxyRegistry.tableIdFor(proxy.entityId(), ownerId)
-                )) {
-                    return false;
-                }
             }
         }
         return true;
@@ -247,6 +251,7 @@ final class SparrowRayInteractionProxyCoordinator {
         if (removed == null) {
             return;
         }
+        this.entityCount -= proxyCount(removed);
         removed.forEach(this::removeActive);
     }
 
@@ -266,6 +271,7 @@ final class SparrowRayInteractionProxyCoordinator {
             } else {
                 this.regions.put(regionKey, Map.copyOf(remaining));
             }
+            this.entityCount -= removed.proxies().size();
             this.removeActive(viewerId, removed);
         }
     }
@@ -274,13 +280,15 @@ final class SparrowRayInteractionProxyCoordinator {
         for (String regionKey : List.copyOf(this.regions.keySet())) {
             this.remove(regionKey);
         }
-        ClientInteractionProxyRegistry.clearTable(this.session.id());
+        this.entityCount = 0;
+        ClientInteractionProxyRegistry.clearTable(this.tableId);
     }
 
     synchronized void shutdown() {
         Map<String, Map<UUID, ActiveProxies>> activeRegions = Map.copyOf(this.regions);
         this.regions.clear();
-        ClientInteractionProxyRegistry.clearTable(this.session.id());
+        this.entityCount = 0;
+        ClientInteractionProxyRegistry.clearTable(this.tableId);
         activeRegions.values().forEach(activeByViewer -> activeByViewer.forEach((viewerId, active) -> {
             if (active.viewer().isOnline()) {
                 this.destroyQuietly(active.viewer(), active.proxies());
@@ -289,11 +297,13 @@ final class SparrowRayInteractionProxyCoordinator {
     }
 
     synchronized int entityCount() {
+        return this.entityCount;
+    }
+
+    private static int proxyCount(Map<UUID, ActiveProxies> activeByViewer) {
         int count = 0;
-        for (Map<UUID, ActiveProxies> activeByViewer : this.regions.values()) {
-            for (ActiveProxies active : activeByViewer.values()) {
-                count += active.proxies().size();
-            }
+        for (ActiveProxies active : activeByViewer.values()) {
+            count += active.proxies().size();
         }
         return count;
     }
@@ -318,14 +328,14 @@ final class SparrowRayInteractionProxyCoordinator {
         }
     }
 
-    private void unregister(UUID viewerId, List<ClientProxy> proxies) {
-        for (ClientProxy proxy : proxies) {
-            ClientInteractionProxyRegistry.unregister(proxy.entityId(), viewerId, this.session.id());
+    private void unregister(UUID viewerId, ActiveProxies active) {
+        for (int index = 0; index < active.proxies().size(); index++) {
+            ClientInteractionProxyRegistry.unregister(active.entityId(index), viewerId, this.tableId);
         }
     }
 
     private void removeActive(UUID viewerId, ActiveProxies active) {
-        this.unregister(viewerId, active.proxies());
+        this.unregister(viewerId, active);
         if (!active.viewer().isOnline()) {
             return;
         }
@@ -381,8 +391,13 @@ final class SparrowRayInteractionProxyCoordinator {
     private record ActiveProxies(
         Player viewer,
         List<ClientProxy> proxies,
-        List<InteractionGeometry> geometry
+        List<DisplayInteractionRayRegistry.RayInteraction> interactions,
+        List<InteractionGeometry> geometry,
+        int firstEntityId
     ) {
+        private int entityId(int index) {
+            return index == 0 ? this.firstEntityId : this.proxies.get(index).entityId();
+        }
     }
 
     private record PendingSpawn(UUID viewerId, ActiveProxies active) {

--- a/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinator.java
@@ -78,23 +78,23 @@ final class SparrowRayInteractionProxyCoordinator {
                 if (viewerId == null || interactions == null || interactions.isEmpty()) {
                     continue;
                 }
+                ActiveProxies current = previous.get(viewerId);
+                if (current != null
+                    && current.viewer().isOnline()
+                    && this.canReuse(viewerId, current, interactions)) {
+                    next.put(viewerId, current);
+                    continue;
+                }
                 Player viewer = this.session.onlinePlayer(viewerId);
                 if (viewer == null || !viewer.isOnline()) {
                     continue;
                 }
-                ActiveProxies current = previous.get(viewerId);
-                if (this.canReuse(viewerId, viewer, current, interactions)) {
-                    next.put(viewerId, current);
-                    continue;
-                }
-                List<DisplayInteractionRayRegistry.RayInteraction> stableInteractions = List.copyOf(interactions);
-                List<InteractionGeometry> geometry = interactionGeometry(stableInteractions);
-                List<ClientProxy> proxies = List.copyOf(this.backend.create(viewer, stableInteractions));
+                List<InteractionGeometry> geometry = interactionGeometry(interactions);
+                List<ClientProxy> proxies = List.copyOf(this.backend.create(viewer, interactions));
                 if (!proxies.isEmpty()) {
                     ActiveProxies created = new ActiveProxies(
                         viewer,
                         proxies,
-                        stableInteractions,
                         geometry,
                         proxies.get(0).entityId()
                     );
@@ -156,12 +156,10 @@ final class SparrowRayInteractionProxyCoordinator {
             if (viewerId == null || interactions == null || interactions.isEmpty()) {
                 continue;
             }
-            Player viewer = this.session.onlinePlayer(viewerId);
-            if (viewer == null || !viewer.isOnline()) {
-                continue;
-            }
             ActiveProxies active = previous.get(viewerId);
-            if (!this.canReuse(viewerId, viewer, active, interactions)) {
+            if (active == null
+                || !active.viewer().isOnline()
+                || !this.canReuse(viewerId, active, interactions)) {
                 return false;
             }
             reusableViewers++;
@@ -171,14 +169,10 @@ final class SparrowRayInteractionProxyCoordinator {
 
     private boolean canReuse(
         UUID viewerId,
-        Player viewer,
         ActiveProxies active,
         List<DisplayInteractionRayRegistry.RayInteraction> interactions
     ) {
-        if (active == null || active.viewer() != viewer || active.proxies().isEmpty()) {
-            return false;
-        }
-        if (active.interactions() != interactions && !sameGeometry(active.geometry(), interactions)) {
+        if (active == null || active.proxies().isEmpty() || !sameGeometry(active.geometry(), interactions)) {
             return false;
         }
         return this.hasOwnership(viewerId, active);
@@ -391,7 +385,6 @@ final class SparrowRayInteractionProxyCoordinator {
     private record ActiveProxies(
         Player viewer,
         List<ClientProxy> proxies,
-        List<DisplayInteractionRayRegistry.RayInteraction> interactions,
         List<InteractionGeometry> geometry,
         int firstEntityId
     ) {

--- a/src/test/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinatorTest.java
+++ b/src/test/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinatorTest.java
@@ -126,7 +126,7 @@ final class SparrowRayInteractionProxyCoordinatorTest {
     }
 
     @Test
-    void sameImmutableInteractionSnapshotReusesWithoutRepeatedIdentityReads() {
+    void unchangedRegionReusesWithoutRepeatedSessionOrIdentityReads() {
         TableSessionContext session = mock(TableSessionContext.class);
         SparrowRayInteractionProxyCoordinator.Backend backend = mock(
             SparrowRayInteractionProxyCoordinator.Backend.class
@@ -162,11 +162,12 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         verify(backend, times(1)).spawn(viewer, List.of(proxy));
         verify(proxy, times(1)).entityId();
         verify(session, times(1)).id();
+        verify(session, times(1)).onlinePlayer(VIEWER_ID);
         assertEquals(1, coordinator.entityCount());
     }
 
     @Test
-    void mutableInteractionListGeometryChangeCannotHitIdentityFastPath() {
+    void mutableInteractionListGeometryChangeForcesRebuild() {
         TableSessionContext session = mock(TableSessionContext.class);
         SparrowRayInteractionProxyCoordinator.Backend backend = mock(
             SparrowRayInteractionProxyCoordinator.Backend.class
@@ -254,6 +255,55 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         assertNull(ClientInteractionProxyRegistry.tableIdFor(1208, VIEWER_ID));
         verify(firstProxy, times(1)).entityId();
         verify(secondProxy, times(3)).entityId();
+    }
+
+    @Test
+    void offlineCachedViewerUsesFreshSessionPlayer() {
+        TableSessionContext session = mock(TableSessionContext.class);
+        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
+            SparrowRayInteractionProxyCoordinator.Backend.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy reconnectedProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        Player firstViewer = mock(Player.class);
+        Player reconnectedViewer = mock(Player.class);
+        when(session.id()).thenReturn("table-a");
+        when(session.onlinePlayer(VIEWER_ID)).thenReturn(firstViewer).thenReturn(reconnectedViewer);
+        when(firstViewer.isOnline()).thenReturn(true);
+        when(reconnectedViewer.isOnline()).thenReturn(true);
+        when(backend.available()).thenReturn(true);
+        when(backend.create(eq(firstViewer), any())).thenReturn(List.of(firstProxy));
+        when(backend.create(eq(reconnectedViewer), any())).thenReturn(List.of(reconnectedProxy));
+        when(firstProxy.entityId()).thenReturn(1211);
+        when(reconnectedProxy.entityId()).thenReturn(1212);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(1).run();
+            return null;
+        }).when(session).runForViewer(any(Player.class), any(Runnable.class));
+        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
+            session,
+            backend
+        );
+        Map<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> interactions = Map.of(
+            VIEWER_ID,
+            List.of(interaction())
+        );
+
+        coordinator.replace("actions", interactions);
+        when(firstViewer.isOnline()).thenReturn(false);
+        coordinator.replace("actions", interactions);
+
+        verify(backend).spawn(firstViewer, List.of(firstProxy));
+        verify(backend).spawn(reconnectedViewer, List.of(reconnectedProxy));
+        verify(backend, never()).destroy(firstViewer, List.of(firstProxy));
+        verify(session, times(2)).onlinePlayer(VIEWER_ID);
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1211, VIEWER_ID));
+        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1212, VIEWER_ID));
+        assertEquals(1, coordinator.entityCount());
     }
 
     @Test

--- a/src/test/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinatorTest.java
+++ b/src/test/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinatorTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,8 +75,6 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         assertNull(ClientInteractionProxyRegistry.tableIdFor(1201, VIEWER_ID));
         assertEquals(0, coordinator.entityCount());
         verify(backend).destroy(viewer, List.of(proxy));
-        verify(session, times(1)).id();
-        verify(proxy, times(1)).entityId();
     }
 
     @Test
@@ -126,7 +123,7 @@ final class SparrowRayInteractionProxyCoordinatorTest {
     }
 
     @Test
-    void unchangedRegionReusesWithoutRepeatedSessionOrIdentityReads() {
+    void unchangedGeometryReusesClientProxyWithoutMorePacketsOrViewerLookups() {
         TableSessionContext session = mock(TableSessionContext.class);
         SparrowRayInteractionProxyCoordinator.Backend backend = mock(
             SparrowRayInteractionProxyCoordinator.Backend.class
@@ -149,112 +146,15 @@ final class SparrowRayInteractionProxyCoordinatorTest {
             session,
             backend
         );
-        List<DisplayInteractionRayRegistry.RayInteraction> interactions = List.of(interaction());
-        Map<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> interactionsByViewer = Map.of(
-            VIEWER_ID,
-            interactions
-        );
 
-        coordinator.replace("actions", interactionsByViewer);
-        coordinator.replace("actions", interactionsByViewer);
+        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
+        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
 
         verify(backend, times(1)).create(eq(viewer), any());
         verify(backend, times(1)).spawn(viewer, List.of(proxy));
-        verify(proxy, times(1)).entityId();
-        verify(session, times(1)).id();
+        verify(backend, never()).destroy(viewer, List.of(proxy));
         verify(session, times(1)).onlinePlayer(VIEWER_ID);
         assertEquals(1, coordinator.entityCount());
-    }
-
-    @Test
-    void mutableInteractionListGeometryChangeForcesRebuild() {
-        TableSessionContext session = mock(TableSessionContext.class);
-        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
-            SparrowRayInteractionProxyCoordinator.Backend.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy changedProxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        Player viewer = mock(Player.class);
-        when(session.id()).thenReturn("table-a");
-        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
-        when(viewer.isOnline()).thenReturn(true);
-        when(backend.available()).thenReturn(true);
-        when(backend.create(eq(viewer), any()))
-            .thenReturn(List.of(firstProxy))
-            .thenReturn(List.of(changedProxy));
-        when(firstProxy.entityId()).thenReturn(1205);
-        when(changedProxy.entityId()).thenReturn(1206);
-        doAnswer(invocation -> {
-            invocation.<Runnable>getArgument(1).run();
-            return null;
-        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
-        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
-            session,
-            backend
-        );
-        List<DisplayInteractionRayRegistry.RayInteraction> interactions = new ArrayList<>();
-        interactions.add(interaction());
-        Map<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> interactionsByViewer = Map.of(
-            VIEWER_ID,
-            interactions
-        );
-
-        coordinator.replace("actions", interactionsByViewer);
-        interactions.set(0, interaction("view:river", 0.75F));
-        coordinator.replace("actions", interactionsByViewer);
-
-        verify(backend, times(2)).create(eq(viewer), any());
-        verify(backend).destroy(viewer, List.of(firstProxy));
-        verify(backend).spawn(viewer, List.of(firstProxy));
-        verify(backend).spawn(viewer, List.of(changedProxy));
-        assertNull(ClientInteractionProxyRegistry.tableIdFor(1205, VIEWER_ID));
-        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1206, VIEWER_ID));
-        assertEquals(1, coordinator.entityCount());
-    }
-
-    @Test
-    void multipleProxyOwnershipRemainsCompleteWithCachedFirstEntityId() {
-        TableSessionContext session = mock(TableSessionContext.class);
-        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
-            SparrowRayInteractionProxyCoordinator.Backend.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy secondProxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        Player viewer = mock(Player.class);
-        when(session.id()).thenReturn("table-a");
-        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
-        when(viewer.isOnline()).thenReturn(true);
-        when(backend.available()).thenReturn(true);
-        when(backend.create(eq(viewer), any())).thenReturn(List.of(firstProxy, secondProxy));
-        when(firstProxy.entityId()).thenReturn(1207);
-        when(secondProxy.entityId()).thenReturn(1208);
-        doAnswer(invocation -> {
-            invocation.<Runnable>getArgument(1).run();
-            return null;
-        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
-        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
-            session,
-            backend
-        );
-
-        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
-
-        assertTrue(coordinator.isCurrent("actions", Set.of(VIEWER_ID)));
-        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1207, VIEWER_ID));
-        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1208, VIEWER_ID));
-        coordinator.remove("actions");
-        assertNull(ClientInteractionProxyRegistry.tableIdFor(1207, VIEWER_ID));
-        assertNull(ClientInteractionProxyRegistry.tableIdFor(1208, VIEWER_ID));
-        verify(firstProxy, times(1)).entityId();
-        verify(secondProxy, times(3)).entityId();
     }
 
     @Test
@@ -278,8 +178,8 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         when(backend.available()).thenReturn(true);
         when(backend.create(eq(firstViewer), any())).thenReturn(List.of(firstProxy));
         when(backend.create(eq(reconnectedViewer), any())).thenReturn(List.of(reconnectedProxy));
-        when(firstProxy.entityId()).thenReturn(1211);
-        when(reconnectedProxy.entityId()).thenReturn(1212);
+        when(firstProxy.entityId()).thenReturn(1205);
+        when(reconnectedProxy.entityId()).thenReturn(1206);
         doAnswer(invocation -> {
             invocation.<Runnable>getArgument(1).run();
             return null;
@@ -301,94 +201,12 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         verify(backend).spawn(reconnectedViewer, List.of(reconnectedProxy));
         verify(backend, never()).destroy(firstViewer, List.of(firstProxy));
         verify(session, times(2)).onlinePlayer(VIEWER_ID);
-        assertNull(ClientInteractionProxyRegistry.tableIdFor(1211, VIEWER_ID));
-        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1212, VIEWER_ID));
-        assertEquals(1, coordinator.entityCount());
-    }
-
-    @Test
-    void cachedEntityCountTracksTheSameViewerAcrossMultipleRegions() {
-        TableSessionContext session = mock(TableSessionContext.class);
-        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
-            SparrowRayInteractionProxyCoordinator.Backend.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy secondProxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        Player viewer = mock(Player.class);
-        when(session.id()).thenReturn("table-a");
-        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
-        when(viewer.isOnline()).thenReturn(true);
-        when(backend.available()).thenReturn(true);
-        when(backend.create(eq(viewer), any()))
-            .thenReturn(List.of(firstProxy))
-            .thenReturn(List.of(secondProxy));
-        when(firstProxy.entityId()).thenReturn(1209);
-        when(secondProxy.entityId()).thenReturn(1210);
-        doAnswer(invocation -> {
-            invocation.<Runnable>getArgument(1).run();
-            return null;
-        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
-        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
-            session,
-            backend
-        );
-
-        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
-        coordinator.replace("hand", Map.of(VIEWER_ID, List.of(interaction())));
-
-        assertEquals(2, coordinator.entityCount());
-        coordinator.removeViewer(VIEWER_ID);
-        assertEquals(0, coordinator.entityCount());
-        assertNull(ClientInteractionProxyRegistry.tableIdFor(1209, VIEWER_ID));
-        assertNull(ClientInteractionProxyRegistry.tableIdFor(1210, VIEWER_ID));
-    }
-
-    @Test
-    void unchangedGeometryWithDifferentActionReusesClientProxyWithoutMorePackets() {
-        TableSessionContext session = mock(TableSessionContext.class);
-        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
-            SparrowRayInteractionProxyCoordinator.Backend.class
-        );
-        SparrowRayInteractionProxyCoordinator.ClientProxy proxy = mock(
-            SparrowRayInteractionProxyCoordinator.ClientProxy.class
-        );
-        Player viewer = mock(Player.class);
-        when(session.id()).thenReturn("table-a");
-        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
-        when(viewer.isOnline()).thenReturn(true);
-        when(backend.available()).thenReturn(true);
-        when(backend.create(eq(viewer), any())).thenReturn(List.of(proxy));
-        when(proxy.entityId()).thenReturn(1204);
-        doAnswer(invocation -> {
-            invocation.<Runnable>getArgument(1).run();
-            return null;
-        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
-        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
-            session,
-            backend
-        );
-
-        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
-        coordinator.replace(
-            "actions",
-            Map.of(VIEWER_ID, List.of(interaction("view:river:updated", 0.5F)))
-        );
-
-        verify(backend, times(1)).create(eq(viewer), any());
-        verify(backend, times(1)).spawn(viewer, List.of(proxy));
-        verify(backend, never()).destroy(viewer, List.of(proxy));
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1205, VIEWER_ID));
+        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1206, VIEWER_ID));
         assertEquals(1, coordinator.entityCount());
     }
 
     private static DisplayInteractionRayRegistry.RayInteraction interaction() {
-        return interaction("view:river", 0.5F);
-    }
-
-    private static DisplayInteractionRayRegistry.RayInteraction interaction(String command, float width) {
         return new DisplayInteractionRayRegistry.RayInteraction(
             WORLD_ID,
             0.0D,
@@ -396,10 +214,10 @@ final class SparrowRayInteractionProxyCoordinatorTest {
             3.0D,
             1.0D,
             0.0D,
-            width,
+            0.5F,
             0.3F,
             0.0F,
-            DisplayClickAction.playerCommand("table-a", VIEWER_ID, command)
+            DisplayClickAction.playerCommand("table-a", VIEWER_ID, "view:river")
         );
     }
 }

--- a/src/test/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinatorTest.java
+++ b/src/test/java/top/ellan/mahjong/table/render/SparrowRayInteractionProxyCoordinatorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +76,8 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         assertNull(ClientInteractionProxyRegistry.tableIdFor(1201, VIEWER_ID));
         assertEquals(0, coordinator.entityCount());
         verify(backend).destroy(viewer, List.of(proxy));
+        verify(session, times(1)).id();
+        verify(proxy, times(1)).entityId();
     }
 
     @Test
@@ -123,7 +126,179 @@ final class SparrowRayInteractionProxyCoordinatorTest {
     }
 
     @Test
-    void unchangedGeometryReusesClientProxyWithoutMorePackets() {
+    void sameImmutableInteractionSnapshotReusesWithoutRepeatedIdentityReads() {
+        TableSessionContext session = mock(TableSessionContext.class);
+        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
+            SparrowRayInteractionProxyCoordinator.Backend.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy proxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        Player viewer = mock(Player.class);
+        when(session.id()).thenReturn("table-a");
+        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
+        when(viewer.isOnline()).thenReturn(true);
+        when(backend.available()).thenReturn(true);
+        when(backend.create(eq(viewer), any())).thenReturn(List.of(proxy));
+        when(proxy.entityId()).thenReturn(1204);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(1).run();
+            return null;
+        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
+        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
+            session,
+            backend
+        );
+        List<DisplayInteractionRayRegistry.RayInteraction> interactions = List.of(interaction());
+        Map<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> interactionsByViewer = Map.of(
+            VIEWER_ID,
+            interactions
+        );
+
+        coordinator.replace("actions", interactionsByViewer);
+        coordinator.replace("actions", interactionsByViewer);
+
+        verify(backend, times(1)).create(eq(viewer), any());
+        verify(backend, times(1)).spawn(viewer, List.of(proxy));
+        verify(proxy, times(1)).entityId();
+        verify(session, times(1)).id();
+        assertEquals(1, coordinator.entityCount());
+    }
+
+    @Test
+    void mutableInteractionListGeometryChangeCannotHitIdentityFastPath() {
+        TableSessionContext session = mock(TableSessionContext.class);
+        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
+            SparrowRayInteractionProxyCoordinator.Backend.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy changedProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        Player viewer = mock(Player.class);
+        when(session.id()).thenReturn("table-a");
+        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
+        when(viewer.isOnline()).thenReturn(true);
+        when(backend.available()).thenReturn(true);
+        when(backend.create(eq(viewer), any()))
+            .thenReturn(List.of(firstProxy))
+            .thenReturn(List.of(changedProxy));
+        when(firstProxy.entityId()).thenReturn(1205);
+        when(changedProxy.entityId()).thenReturn(1206);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(1).run();
+            return null;
+        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
+        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
+            session,
+            backend
+        );
+        List<DisplayInteractionRayRegistry.RayInteraction> interactions = new ArrayList<>();
+        interactions.add(interaction());
+        Map<UUID, List<DisplayInteractionRayRegistry.RayInteraction>> interactionsByViewer = Map.of(
+            VIEWER_ID,
+            interactions
+        );
+
+        coordinator.replace("actions", interactionsByViewer);
+        interactions.set(0, interaction("view:river", 0.75F));
+        coordinator.replace("actions", interactionsByViewer);
+
+        verify(backend, times(2)).create(eq(viewer), any());
+        verify(backend).destroy(viewer, List.of(firstProxy));
+        verify(backend).spawn(viewer, List.of(firstProxy));
+        verify(backend).spawn(viewer, List.of(changedProxy));
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1205, VIEWER_ID));
+        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1206, VIEWER_ID));
+        assertEquals(1, coordinator.entityCount());
+    }
+
+    @Test
+    void multipleProxyOwnershipRemainsCompleteWithCachedFirstEntityId() {
+        TableSessionContext session = mock(TableSessionContext.class);
+        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
+            SparrowRayInteractionProxyCoordinator.Backend.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy secondProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        Player viewer = mock(Player.class);
+        when(session.id()).thenReturn("table-a");
+        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
+        when(viewer.isOnline()).thenReturn(true);
+        when(backend.available()).thenReturn(true);
+        when(backend.create(eq(viewer), any())).thenReturn(List.of(firstProxy, secondProxy));
+        when(firstProxy.entityId()).thenReturn(1207);
+        when(secondProxy.entityId()).thenReturn(1208);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(1).run();
+            return null;
+        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
+        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
+            session,
+            backend
+        );
+
+        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
+
+        assertTrue(coordinator.isCurrent("actions", Set.of(VIEWER_ID)));
+        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1207, VIEWER_ID));
+        assertEquals("table-a", ClientInteractionProxyRegistry.tableIdFor(1208, VIEWER_ID));
+        coordinator.remove("actions");
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1207, VIEWER_ID));
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1208, VIEWER_ID));
+        verify(firstProxy, times(1)).entityId();
+        verify(secondProxy, times(3)).entityId();
+    }
+
+    @Test
+    void cachedEntityCountTracksTheSameViewerAcrossMultipleRegions() {
+        TableSessionContext session = mock(TableSessionContext.class);
+        SparrowRayInteractionProxyCoordinator.Backend backend = mock(
+            SparrowRayInteractionProxyCoordinator.Backend.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy firstProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        SparrowRayInteractionProxyCoordinator.ClientProxy secondProxy = mock(
+            SparrowRayInteractionProxyCoordinator.ClientProxy.class
+        );
+        Player viewer = mock(Player.class);
+        when(session.id()).thenReturn("table-a");
+        when(session.onlinePlayer(VIEWER_ID)).thenReturn(viewer);
+        when(viewer.isOnline()).thenReturn(true);
+        when(backend.available()).thenReturn(true);
+        when(backend.create(eq(viewer), any()))
+            .thenReturn(List.of(firstProxy))
+            .thenReturn(List.of(secondProxy));
+        when(firstProxy.entityId()).thenReturn(1209);
+        when(secondProxy.entityId()).thenReturn(1210);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(1).run();
+            return null;
+        }).when(session).runForViewer(eq(viewer), any(Runnable.class));
+        SparrowRayInteractionProxyCoordinator coordinator = new SparrowRayInteractionProxyCoordinator(
+            session,
+            backend
+        );
+
+        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
+        coordinator.replace("hand", Map.of(VIEWER_ID, List.of(interaction())));
+
+        assertEquals(2, coordinator.entityCount());
+        coordinator.removeViewer(VIEWER_ID);
+        assertEquals(0, coordinator.entityCount());
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1209, VIEWER_ID));
+        assertNull(ClientInteractionProxyRegistry.tableIdFor(1210, VIEWER_ID));
+    }
+
+    @Test
+    void unchangedGeometryWithDifferentActionReusesClientProxyWithoutMorePackets() {
         TableSessionContext session = mock(TableSessionContext.class);
         SparrowRayInteractionProxyCoordinator.Backend backend = mock(
             SparrowRayInteractionProxyCoordinator.Backend.class
@@ -148,7 +323,10 @@ final class SparrowRayInteractionProxyCoordinatorTest {
         );
 
         coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
-        coordinator.replace("actions", Map.of(VIEWER_ID, List.of(interaction())));
+        coordinator.replace(
+            "actions",
+            Map.of(VIEWER_ID, List.of(interaction("view:river:updated", 0.5F)))
+        );
 
         verify(backend, times(1)).create(eq(viewer), any());
         verify(backend, times(1)).spawn(viewer, List.of(proxy));
@@ -157,6 +335,10 @@ final class SparrowRayInteractionProxyCoordinatorTest {
     }
 
     private static DisplayInteractionRayRegistry.RayInteraction interaction() {
+        return interaction("view:river", 0.5F);
+    }
+
+    private static DisplayInteractionRayRegistry.RayInteraction interaction(String command, float width) {
         return new DisplayInteractionRayRegistry.RayInteraction(
             WORLD_ID,
             0.0D,
@@ -164,10 +346,10 @@ final class SparrowRayInteractionProxyCoordinatorTest {
             3.0D,
             1.0D,
             0.0D,
-            0.5F,
+            width,
             0.3F,
             0.0F,
-            DisplayClickAction.playerCommand("table-a", VIEWER_ID, "view:river")
+            DisplayClickAction.playerCommand("table-a", VIEWER_ID, command)
         );
     }
 }


### PR DESCRIPTION
## Summary
- let unchanged active viewers reuse their stored Player without repeating `session.onlinePlayer(viewerId)`
- resolve a fresh session Player only when no active proxy exists, geometry/ownership changed, or the cached Player is offline
- preserve the original coordinator, proxy record, registry and allocation-sensitive object layouts
- add regression coverage proving unchanged regions perform one viewer lookup while reconnects switch to a fresh Player

## Performance
Latest local protected-profile smoke comparison against `origin/dev`:
- 1 viewer: `407.2 ns/op` -> `326.4 ns/op` (~19.8% lower)
- 4 viewers: `963.9 ns/op` -> `868.5 ns/op` (~9.9% lower)
- 32 viewers: `5209.7 ns/op` -> `4884.3 ns/op` (~6.2% lower)
- 1-viewer allocation: `2312 B/op` -> `2224 B/op` (~3.8% lower)
- 4-viewer allocation: `5536 B/op` -> `5568 B/op` (~0.6% increase)
- 32-viewer allocation: `31400 B/op` -> `31376 B/op` (flat/slightly lower)

Two earlier protected runs exposed escape-analysis regressions from added cache fields. Commit `ef9ec5e` removes all layout-changing caches and leaves only the viewer-lookup fast path.

## Test plan
- [x] `SparrowRayInteractionProxyCoordinatorTest`
- [x] unchanged-region viewer lookup count
- [x] offline cached viewer reconnect coverage
- [x] null-session `TableRegionKeyCacheTest` compatibility
- [x] `spotlessCheck`
- [x] full `check assemble` (709 tests, 7 skipped)
- [x] local `RayProxyCoordinatorBenchmark` smoke A/B
- [ ] protected `ray-proxy` paired A/B gate for `ef9ec5e`
- [ ] Linux, Windows, and macOS CI for `ef9ec5e`