### PR TITLE
fix(interact): widen click dedup window to stop cross-tick double-firing

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/MahjongTableManager.java
+++ b/src/main/java/top/ellan/mahjong/table/core/MahjongTableManager.java
@@ -46,8 +46,8 @@ import top.ellan.mahjong.runtime.PluginTask;
 
 public final class MahjongTableManager implements Listener {
     private static final String ADMIN_PERMISSION = "mahjongpaper.admin";
-    private static final long DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS = 40_000_000L;
-    private static final long DUPLICATE_HAND_TILE_CLICK_WINDOW_NANOS = 40_000_000L;
+    private static final long DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS = 150_000_000L;
+    private static final long DUPLICATE_HAND_TILE_CLICK_WINDOW_NANOS = 150_000_000L;
     private static final long RECENT_DISPLAY_ACTION_TTL_SECONDS = 60L;
     private static final long RECENT_HAND_TILE_CLICK_TTL_SECONDS = 60L;
     private static final double PERSISTED_TABLE_CLEANUP_RADIUS_XZ = 4.5D;

--- a/src/main/java/top/ellan/mahjong/table/core/TableEventCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/core/TableEventCoordinator.java
@@ -41,13 +41,13 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.util.RayTraceResult;
 
 final class TableEventCoordinator implements Listener {
-    private static final long DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS = 40_000_000L;
+    private static final long DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS = 150_000_000L;
     private static final long OVERHEAD_EXIT_GUARD_SECONDS = 2L;
     private static final double FLAT_INTERACTION_MAX_DISTANCE = 6.0D;
     private static final double FLAT_INTERACTION_BLOCK_EPSILON = 0.05D;
     /**
      * Bounded TTL on the per-player recent-action cache. The dedup window is
-     * 40ms (DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS), so anything older than a
+     * 150ms (DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS), so anything older than a
      * few seconds is by definition not a duplicate of a fresh click — but the
      * previous bare ConcurrentHashMap only evicted on PlayerQuitEvent, which
      * on Folia can occasionally be missed when the player's entity region


### PR DESCRIPTION
## Problem

Players observed that a single physical click on any ray-based table control (join seat, hand tile, ready toggle, viewer commands) was being processed twice. For hand tiles this was especially destructive because the click toggle is select → discard, so one press discarded immediately.

## Root cause

PlayerUseUnknownEntityEvent (fired by the Sparrow Heart client-only click proxies) does not implement Cancellable, so onClientInteractionProxy cannot suppress the event. Paper then fires a follow-up PlayerInteractEvent for the same physical click, which onFlatDisplayInteract processes again. The previous dedup window was 40ms, which is shorter than one server tick (50ms); when the two events landed on different ticks the second one slipped through and the action ran twice. The right-click + ARM_SWING pairing has the same cross-tick failure mode.

## Fix

Raise the dedup windows in TableEventCoordinator and MahjongTableManager from 40ms to 150ms (3 ticks) so the follow-up event is always caught:

- \TableEventCoordinator.DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS\ — first dedup layer, covers all action types
- \MahjongTableManager.DUPLICATE_DISPLAY_ACTION_WINDOW_NANOS\ — second dedup layer
- \MahjongTableManager.DUPLICATE_HAND_TILE_CLICK_WINDOW_NANOS\ — third dedup layer, hand-tile specific

The fix is uniform across all \DisplayClickAction\ types because \sameDisplayAction\ compares \ctionType + tableId + ownerId + tileIndex + seatWind + command\, so JOIN_SEAT / TOGGLE_READY / PLAYER_COMMAND benefit from the same window.

## Safety

- Sichuan exchange phase already bypasses hand-tile dedup (\!session.isSichuanExchangePhase(ownerId)\), so rapid exchange clicks are unaffected.
- 150ms is well below human double-click perception for distinct actions; legitimate consecutive clicks on different tiles / seats remain distinguishable because \sameDisplayAction\ requires field-level equality.
- No behavior change to game rules — only the dedup timing window moves.

## Verification

- \compileJava\ passes.
- \TableEventCoordinatorFlatInteractionTest\ passes, including:
  - \ightClickAndArmSwingBothCancelButExecuteTheSameActionOnlyOnce\ (existing dedup guarantee)
  - \ownedClientProxyUsesTheSameExactRayActionAndSwingsForRightClick\ (proxy path)
- \SessionHandSelectionCoordinatorTest\ passes (select → discard toggle semantics preserved).
- \MahjongTableManagerTest\, \TableEventCoordinatorDisconnectTest\, \TableEventCoordinatorSeatAttendanceTest\ pass.

This is a behavior-preserving bug fix; no AB gate needed.