### PR TITLE
perf: add i18n benchmark profile for parametrised message rendering

### DIFF
--- a/.github/workflows/performance-ab.yml
+++ b/.github/workflows/performance-ab.yml
@@ -33,6 +33,7 @@ on:
         options:
           - snapshot
           - gb-bot
+          - i18n
           - region-fingerprint
           - display-spawn
           - region-queue
@@ -154,6 +155,7 @@ jobs:
           choices = {
               "performance-snapshot": "snapshot",
               "performance-gb-bot": "gb-bot",
+              "performance-i18n": "i18n",
               "performance-region-fingerprint": "region-fingerprint",
               "performance-display-spawn": "display-spawn",
               "performance-region-queue": "region-queue",

--- a/perf/ab/gate-config.json
+++ b/perf/ab/gate-config.json
@@ -315,67 +315,6 @@
     }
   },
   "benchmarks": [
-      {
-        "id": "i18n.bot-name.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.bot-name.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-empty.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-empty.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.center-waiting.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.center-waiting.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status-component.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status-component.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-
     {
       "id": "infra.fingerprint.time",
       "benchmark": "top.ellan.mahjong.perf.DelimitedFingerprintBuilderBenchmark.buildRepresentativeFingerprint",
@@ -757,6 +696,66 @@
     {
       "id": "ray.viewers32.alloc",
       "benchmark": "top.ellan.mahjong.perf.RayProxyCoordinatorBenchmark.proxyPlan32Viewers",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.bot-name.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.bot-name.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-empty.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-empty.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.center-waiting.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.center-waiting.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status-component.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status-component.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
       "metric": "gc.alloc.rate.norm",
       "direction": "lower"
     }

--- a/perf/ab/gate-config.json
+++ b/perf/ab/gate-config.json
@@ -46,6 +46,29 @@
     "require_ci_contains_zero": true
   },
   "profiles": {
+    "i18n": {
+      "include": "^top\\.ellan\\.mahjong\\.perf\\.LocalizedMessagesBenchmark\\.(?:plainBotName|plainSeatStatus|plainSeatEmpty|plainCenterWaiting|renderSeatStatus)$",
+      "benchmark_ids": [
+        "i18n.bot-name.time",
+        "i18n.bot-name.alloc",
+        "i18n.seat-status.time",
+        "i18n.seat-status.alloc",
+        "i18n.seat-empty.time",
+        "i18n.seat-empty.alloc",
+        "i18n.center-waiting.time",
+        "i18n.center-waiting.alloc",
+        "i18n.seat-status-component.time",
+        "i18n.seat-status-component.alloc"
+      ],
+      "minimum_passes": 2,
+      "must_pass": [
+        "i18n.bot-name.time",
+        "i18n.seat-status.time"
+      ],
+      "required_classes": [
+        "top/ellan/mahjong/i18n/LocalizedMessages.class"
+      ]
+    },
     "infra": {
       "include": "^top\\.ellan\\.mahjong\\.perf\\.DelimitedFingerprintBuilderBenchmark\\.buildRepresentativeFingerprint$",
       "benchmark_ids": [
@@ -292,6 +315,67 @@
     }
   },
   "benchmarks": [
+      {
+        "id": "i18n.bot-name.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.bot-name.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-empty.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-empty.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.center-waiting.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.center-waiting.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status-component.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status-component.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+
     {
       "id": "infra.fingerprint.time",
       "benchmark": "top.ellan.mahjong.perf.DelimitedFingerprintBuilderBenchmark.buildRepresentativeFingerprint",

--- a/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
+++ b/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
@@ -54,6 +54,40 @@ public final class LocalizedMessages {
         return this.plainTextSerializer.serialize(this.render(locale, key, placeholders));
     }
 
+    /**
+     * Renders a message with placeholders supplied as a plain key/value map.
+     *
+     * <p>This overload is behaviourally identical to the {@link TagResolver} variant
+     * (placeholders are resolved by tag name, so map iteration order is irrelevant). It
+     * exists so hot rendering paths can be measured and cached through a single,
+     * stable placeholder representation.
+     */
+    public Component render(Locale locale, String key, Map<String, String> placeholders) {
+        return this.render(locale, key, resolvers(placeholders));
+    }
+
+    /**
+     * Renders a message to plain text with placeholders supplied as a key/value map.
+     *
+     * <p>See {@link #render(Locale, String, Map)} for the contract shared with the
+     * {@link TagResolver} variant.
+     */
+    public String plain(Locale locale, String key, Map<String, String> placeholders) {
+        return this.plain(locale, key, resolvers(placeholders));
+    }
+
+    /**
+     * Formats a number using the locale-aware integer format used by {@link #number}.
+     */
+    public String formatNumber(Locale locale, String key, Number value) {
+        Locale formatLocale = this.resolveLocales(locale).get(0);
+        NumberFormat format = this.integerFormats.computeIfAbsent(
+            formatLocale,
+            resolvedLocale -> ThreadLocal.withInitial(() -> NumberFormat.getIntegerInstance(resolvedLocale))
+        ).get();
+        return format.format(value);
+    }
+
     public boolean contains(Locale locale, String key) {
         for (Locale candidate : this.resolveLocales(locale)) {
             if (this.bundle(candidate).containsKey(key)) {
@@ -68,12 +102,16 @@ public final class LocalizedMessages {
     }
 
     public TagResolver number(Locale locale, String key, Number value) {
-        Locale formatLocale = this.resolveLocales(locale).get(0);
-        NumberFormat format = this.integerFormats.computeIfAbsent(
-            formatLocale,
-            resolvedLocale -> ThreadLocal.withInitial(() -> NumberFormat.getIntegerInstance(resolvedLocale))
-        ).get();
-        return Placeholder.unparsed(key, format.format(value));
+        return Placeholder.unparsed(key, this.formatNumber(locale, key, value));
+    }
+
+    private static TagResolver[] resolvers(Map<String, String> placeholders) {
+        TagResolver[] resolvers = new TagResolver[placeholders.size()];
+        int index = 0;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            resolvers[index++] = Placeholder.unparsed(entry.getKey(), entry.getValue());
+        }
+        return resolvers;
     }
 
     public Locale normalizeLocale(String rawLocale) {

--- a/src/perfTest/java/top/ellan/mahjong/perf/LocalizedMessagesBenchmark.java
+++ b/src/perfTest/java/top/ellan/mahjong/perf/LocalizedMessagesBenchmark.java
@@ -1,0 +1,88 @@
+package top.ellan.mahjong.perf;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.text.Component;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import top.ellan.mahjong.i18n.LocalizedMessages;
+
+/**
+ * Exercises the parametrised message rendering paths hit by every render flush.
+ *
+ * <p>Each method mirrors a hot Spark-sampled call site: bot display names
+ * ({@code table.bot_name}), per-seat status lines ({@code table.public.seat_status}),
+ * empty-seat placeholders ({@code table.public.seat_empty}) and the table centre line
+ * ({@code table.public.center_waiting}). Placeholders flow through the {@link Map}-based
+ * overload so both implementations (baseline delegation and cached) share one contract.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class LocalizedMessagesBenchmark {
+    private static final String[] SEATS = {"East", "South", "West", "North"};
+    private static final String[] STATUSES = {"", "Riichi", "", "Ready"};
+
+    private final LocalizedMessages messages = new LocalizedMessages();
+    private final Locale locale = LocalizedMessages.DEFAULT_LOCALE;
+    private final String[] points = {
+        this.messages.formatNumber(this.locale, "points", 25_000),
+        this.messages.formatNumber(this.locale, "points", 18_500),
+        this.messages.formatNumber(this.locale, "points", 36_200),
+        this.messages.formatNumber(this.locale, "points", 5_300)
+    };
+
+    @Benchmark
+    public String plainBotName() {
+        return this.messages.plain(this.locale, "table.bot_name", Map.of("index", "1"))
+            + this.messages.plain(this.locale, "table.bot_name", Map.of("index", "2"))
+            + this.messages.plain(this.locale, "table.bot_name", Map.of("index", "3"))
+            + this.messages.plain(this.locale, "table.bot_name", Map.of("index", "4"));
+    }
+
+    @Benchmark
+    public String plainSeatStatus() {
+        String result = "";
+        for (int index = 0; index < 4; index++) {
+            result += this.messages.plain(
+                this.locale,
+                "table.public.seat_status",
+                Map.of("seat", SEATS[index], "points", this.points[index], "status", STATUSES[index])
+            );
+        }
+        return result;
+    }
+
+    @Benchmark
+    public String plainSeatEmpty() {
+        return this.messages.plain(this.locale, "table.public.seat_empty", Map.of("seat", "South"))
+            + this.messages.plain(this.locale, "table.public.seat_empty", Map.of("seat", "West"));
+    }
+
+    @Benchmark
+    public String plainCenterWaiting() {
+        return this.messages.plain(
+            this.locale,
+            "table.public.center_waiting",
+            Map.of("table_id", "table-7", "summary", "Waiting for South")
+        );
+    }
+
+    @Benchmark
+    public Component renderSeatStatus() {
+        Component result = Component.empty();
+        for (int index = 0; index < 4; index++) {
+            result = result.append(this.messages.render(
+                this.locale,
+                "table.public.seat_status",
+                Map.of("seat", SEATS[index], "points", this.points[index], "status", STATUSES[index])
+            ));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Map<String, String>` placeholder overloads (`render`/`plain`) and `formatNumber` to `LocalizedMessages`. These delegate to the existing `TagResolver` implementations, so behaviour is unchanged — they exist so hot rendering paths share one stable placeholder representation that can be cached and benchmarked.
- Adds `LocalizedMessagesBenchmark` (JMH) covering the Spark-sampled parametrised call sites: `table.bot_name`, `table.public.seat_status`, `table.public.seat_empty`, `table.public.center_waiting`, with time + allocation metrics.
- Adds the `i18n` gate profile (`gate-config.json`) and the corresponding `performance-i18n` workflow label/option.

## Why
A Spark profile of the plugin showed parametrised MiniMessage rendering (no cache today) as a top hotspot during every render flush. This PR is the measurement half of that work: the profile is merged first so the subsequent caching optimisation can be validated through the protected A/B gate.

## Test plan
- [x] `compileJava` + `compileJmhJava` pass
- [x] i18n unit tests pass (`MessageServiceTest`, `LocalizedConfigResourceTest`) with CI toolchain args
- [x] `jmhJar` builds and `LocalizedMessagesBenchmark` runs locally
- [x] `gate-config.json` parses; profile has 10 time/alloc benchmark ids, `minimum_passes=2`, must-pass on bot-name + seat-status time

🤖 Generated with [Claude Code](https://claude.com/claude-code)