### PR TITLE
perf(native): compile handtiles legality regex once as static

### DIFF
--- a/native/gbmahjong/vendor/GB-Mahjong/mahjong/handtiles.cpp
+++ b/native/gbmahjong/vendor/GB-Mahjong/mahjong/handtiles.cpp
@@ -113,7 +113,9 @@ int Handtiles::StringToHandtiles(const std::string &s_ori) {
         }
     }
     //初步检测字符串是否合法
-    std::regex pattern(R"((\[([1-9]{3,4}[msp]|[ESWNCFP]{3,4})(,[123567])?\]|([ESWNCFPa-h]|[1-9]+[msp]))+(\|([ESWN]{2}[01]{4})(\|([a-h]{0,8}|[0-8]))?)?)");
+    // The pattern is compiled once: std::regex construction compiles the
+    // expression, which dominated per-call cost for this hot parse path.
+    static const std::regex pattern(R"((\[([1-9]{3,4}[msp]|[ESWNCFP]{3,4})(,[123567])?\]|([ESWNCFPa-h]|[1-9]+[msp]))+(\|([ESWN]{2}[01]{4})(\|([a-h]{0,8}|[0-8]))?)?)");
     if (!std::regex_match(s, pattern)) {
         return -1; //【错误】：字符串非法
     }


### PR DESCRIPTION
## Summary
- `Handtiles::StringToHandtiles` 每次调用都执行 `std::regex pattern(...)`（正则编译），而该解析在每次 JNI `evaluateFan`/`evaluateTing` 都会触发。
- Spark 采样（https://spark.lucko.me/j9YE2XtMP3）显示 native 热点集中在 `std::__detail::_Compiler` 系列帧（_M_alternative / _M_disjunction / _M_atom / _BracketMatcher ≈ 2740 采样），即正则编译开销。
- 改为函数局部 `static const std::regex`（C++11 起线程安全初始化，cxx_std_20），仅首次调用编译一次。
- 已确认 fan.cpp/pack.cpp/tile.cpp 无其他 per-call 正则构造。

## 门禁说明
权威 A/B 性能门禁（performance-ab.yml）构建 JMH jar 时显式排除 native（`-x configureGbMahjongNative -x buildGbMahjongNative -x packageGbMahjongNative`），**门禁环境无 native lib，无法测量该路径**；按既定流程以本地/CI 集成验证为准：
- 本地 `gradlew buildGbMahjongNative` 编译通过（cmake 4.2.3 + g++ 15.2.0）
- native 相关测试（GbMahjongNativeJsonTest 等）与 bot 回合集成测试通过

## Test plan
- [x] 本地 native 构建成功
- [x] 本地 native/集成测试通过
- [ ] CI test.yml 全量测试通过（无 native 平台跑 JVM 侧测试）