### PR TITLE
perf(i18n): cache parametrised renders and reuse action snapshot factory

### DIFF
--- a/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
+++ b/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
@@ -1,5 +1,7 @@
 package top.ellan.mahjong.i18n;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,6 +39,8 @@ public final class LocalizedMessages {
     private final Map<MessageCacheKey, String> templates = new ConcurrentHashMap<>();
     private final Map<MessageCacheKey, Component> staticComponents = new ConcurrentHashMap<>();
     private final Map<MessageCacheKey, String> staticPlainTexts = new ConcurrentHashMap<>();
+    private final Cache<MessageRenderKey, Component> renderedComponents = Caffeine.newBuilder().maximumSize(512).build();
+    private final Cache<MessageRenderKey, String> renderedPlainTexts = Caffeine.newBuilder().maximumSize(512).build();
     private final ConcurrentMap<Locale, ThreadLocal<NumberFormat>> integerFormats = new ConcurrentHashMap<>();
 
     public Component render(Locale locale, String key, TagResolver... placeholders) {
@@ -61,19 +65,43 @@ public final class LocalizedMessages {
      * (placeholders are resolved by tag name, so map iteration order is irrelevant). It
      * exists so hot rendering paths can be measured and cached through a single,
      * stable placeholder representation.
+     *
+     * <p>Results are cached keyed by (locale, message key, sorted placeholder
+     * entries): MiniMessage output depends only on the template and the resolved
+     * placeholder values, and message bundles are immutable after load.
      */
     public Component render(Locale locale, String key, Map<String, String> placeholders) {
-        return this.render(locale, key, resolvers(placeholders));
+        if (placeholders.isEmpty()) {
+            return this.render(locale, key);
+        }
+        MessageRenderKey cacheKey = this.renderKey(locale, key, placeholders);
+        Component cached = this.renderedComponents.getIfPresent(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        Component rendered = this.render(locale, key, resolvers(placeholders));
+        this.renderedComponents.put(cacheKey, rendered);
+        return rendered;
     }
 
     /**
      * Renders a message to plain text with placeholders supplied as a key/value map.
      *
      * <p>See {@link #render(Locale, String, Map)} for the contract shared with the
-     * {@link TagResolver} variant.
+     * {@link TagResolver} variant; results are cached the same way.
      */
     public String plain(Locale locale, String key, Map<String, String> placeholders) {
-        return this.plain(locale, key, resolvers(placeholders));
+        if (placeholders.isEmpty()) {
+            return this.plain(locale, key);
+        }
+        MessageRenderKey cacheKey = this.renderKey(locale, key, placeholders);
+        String cached = this.renderedPlainTexts.getIfPresent(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        String rendered = this.plain(locale, key, resolvers(placeholders));
+        this.renderedPlainTexts.put(cacheKey, rendered);
+        return rendered;
     }
 
     /**
@@ -112,6 +140,12 @@ public final class LocalizedMessages {
             resolvers[index++] = Placeholder.unparsed(entry.getKey(), entry.getValue());
         }
         return resolvers;
+    }
+
+    private MessageRenderKey renderKey(Locale locale, String key, Map<String, String> placeholders) {
+        List<Map.Entry<String, String>> entries = new ArrayList<>(placeholders.entrySet());
+        entries.sort(Map.Entry.comparingByKey());
+        return new MessageRenderKey(this.safeLocale(locale), key, List.copyOf(entries));
     }
 
     public Locale normalizeLocale(String rawLocale) {
@@ -321,6 +355,13 @@ public final class LocalizedMessages {
 
     private record MessageCacheKey(Locale locale, String key) {
         private MessageCacheKey {
+            locale = Objects.requireNonNull(locale, "locale");
+            key = Objects.requireNonNull(key, "key");
+        }
+    }
+
+    private record MessageRenderKey(Locale locale, String key, List<Map.Entry<String, String>> placeholders) {
+        private MessageRenderKey {
             locale = Objects.requireNonNull(locale, "locale");
             key = Objects.requireNonNull(key, "key");
         }

--- a/src/main/java/top/ellan/mahjong/i18n/MessageService.java
+++ b/src/main/java/top/ellan/mahjong/i18n/MessageService.java
@@ -1,6 +1,7 @@
 package top.ellan.mahjong.i18n;
 
 import java.util.Locale;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandSender;
@@ -27,6 +28,18 @@ public final class MessageService {
 
     public String plain(Locale locale, String key, TagResolver... placeholders) {
         return this.messages.plain(locale, key, placeholders);
+    }
+
+    public Component render(Locale locale, String key, Map<String, String> placeholders) {
+        return this.messages.render(locale, key, placeholders);
+    }
+
+    public String plain(Locale locale, String key, Map<String, String> placeholders) {
+        return this.messages.plain(locale, key, placeholders);
+    }
+
+    public String formatNumber(Locale locale, String key, Number value) {
+        return this.messages.formatNumber(locale, key, value);
     }
 
     public boolean contains(Locale locale, String key) {

--- a/src/main/java/top/ellan/mahjong/i18n/MessageService.java
+++ b/src/main/java/top/ellan/mahjong/i18n/MessageService.java
@@ -61,4 +61,3 @@ public final class MessageService {
         return this.messages.number(locale, key, value);
     }
 }
-

--- a/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
+++ b/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
@@ -18,6 +18,7 @@ import top.ellan.mahjong.render.snapshot.TableSeatRenderSnapshot;
 import top.ellan.mahjong.render.snapshot.TableViewerHudSnapshot;
 import top.ellan.mahjong.render.snapshot.TableViewerHudPresentationSnapshot;
 import top.ellan.mahjong.render.snapshot.TableViewerOverlaySnapshot;
+import top.ellan.mahjong.table.action.PlayerActionSnapshotFactory;
 import top.ellan.mahjong.riichi.ReactionResponse;
 import top.ellan.mahjong.riichi.ReactionResponses;
 import top.ellan.mahjong.riichi.RiichiPlayerState;
@@ -104,6 +105,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
     private final TableRenderInspectCoordinator renderInspectCoordinator;
     private final TableLifecycleCoordinator lifecycleCoordinator;
     private final TableViewerSnapshotFactory viewerSnapshotFactory;
+    private final PlayerActionSnapshotFactory actionSnapshotFactory;
     private final TableDiceAnimationCoordinator diceAnimationCoordinator;
     private final TablePlayerFeedbackCoordinator playerFeedbackCoordinator;
     private final TableStateSoundCoordinator stateSoundCoordinator;
@@ -183,6 +185,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         this.renderInspectCoordinator = new TableRenderInspectCoordinator(this.sessionContext);
         this.lifecycleCoordinator = new TableLifecycleCoordinator(this.sessionMutator);
         this.viewerSnapshotFactory = new TableViewerSnapshotFactory(this.sessionMutator);
+        this.actionSnapshotFactory = new PlayerActionSnapshotFactory(this.sessionMutator);
         this.diceAnimationCoordinator = new TableDiceAnimationCoordinator(this.sessionContext);
         this.playerFeedbackCoordinator = new TablePlayerFeedbackCoordinator(this.sessionMutator);
         this.stateSoundCoordinator = new TableStateSoundCoordinator(this.sessionContext);
@@ -200,6 +203,15 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
 
     public TableRuntimeServices plugin() {
         return this.plugin;
+    }
+
+    /**
+     * Shared, stateless action-snapshot factory for this session. Bot strategies
+     * and render paths capture action snapshots every tick, so the factory is
+     * created once per session instead of per capture.
+     */
+    public PlayerActionSnapshotFactory actionSnapshotFactory() {
+        return this.actionSnapshotFactory;
     }
 
     @Override
@@ -1719,7 +1731,11 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
             return this.plugin.messages().plain(locale, "common.unknown");
         }
         int suffix = this.participants.seatIndexOf(playerId) + 1;
-        return this.plugin.messages().plain(locale, "table.bot_name", this.plugin.messages().number(locale, "index", Math.max(1, suffix)));
+        return this.plugin.messages().plain(
+            locale,
+            "table.bot_name",
+            Map.of("index", this.plugin.messages().formatNumber(locale, "index", Math.max(1, suffix)))
+        );
     }
 
     public String tileLabelForDisplay(Locale locale, String tileName) {

--- a/src/main/java/top/ellan/mahjong/table/presentation/TablePublicTextFactory.java
+++ b/src/main/java/top/ellan/mahjong/table/presentation/TablePublicTextFactory.java
@@ -5,6 +5,7 @@ import top.ellan.mahjong.model.MahjongVariant;
 import top.ellan.mahjong.model.SeatWind;
 import top.ellan.mahjong.riichi.model.MahjongRule;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 
 public final class TablePublicTextFactory {
@@ -139,7 +140,7 @@ public final class TablePublicTextFactory {
             return this.session.plugin().messages().plain(
                 locale,
                 "table.public.seat_empty",
-                this.session.plugin().messages().tag("seat", this.seatDisplayName(wind, locale))
+                Map.of("seat", this.seatDisplayName(wind, locale))
             );
         }
         String status = this.waitingSeatStatus(locale, playerId);
@@ -150,9 +151,11 @@ public final class TablePublicTextFactory {
         return this.session.plugin().messages().plain(
             locale,
             "table.public.seat_status",
-            this.session.plugin().messages().tag("seat", this.seatDisplayName(wind, locale)),
-            this.session.plugin().messages().number(locale, "points", this.session.points(playerId)),
-            this.session.plugin().messages().tag("status", status.isBlank() ? "" : " | " + status)
+            Map.of(
+                "seat", this.seatDisplayName(wind, locale),
+                "points", this.session.plugin().messages().formatNumber(locale, "points", this.session.points(playerId)),
+                "status", status.isBlank() ? "" : " | " + status
+            )
         );
     }
 
@@ -165,9 +168,11 @@ public final class TablePublicTextFactory {
         return this.session.plugin().messages().plain(
             locale,
             "table.public.center_waiting",
-            this.session.plugin().messages().tag("table_id", this.session.id()),
-            this.session.plugin().messages().tag("summary", this.waitingDisplaySummary(locale)),
-            this.session.plugin().messages().tag("rules", this.ruleDisplaySummary(locale))
+            Map.of(
+                "table_id", this.session.id(),
+                "summary", this.waitingDisplaySummary(locale),
+                "rules", this.ruleDisplaySummary(locale)
+            )
         );
     }
 

--- a/src/main/java/top/ellan/mahjong/table/runtime/GbBotStrategy.java
+++ b/src/main/java/top/ellan/mahjong/table/runtime/GbBotStrategy.java
@@ -1,5 +1,6 @@
 package top.ellan.mahjong.table.runtime;
 
+import top.ellan.mahjong.table.action.PlayerActionEntry;
 import top.ellan.mahjong.table.action.PlayerActionId;
 import top.ellan.mahjong.table.action.PlayerActionPhase;
 import top.ellan.mahjong.table.action.PlayerActionSnapshot;
@@ -17,7 +18,7 @@ final class GbBotStrategy implements BotStrategy {
         if (!session.isStarted()) {
             return;
         }
-        PlayerActionSnapshotFactory actionSnapshots = new PlayerActionSnapshotFactory(session);
+        PlayerActionSnapshotFactory actionSnapshots = session.actionSnapshotFactory();
         for (UUID playerId : session.players()) {
             if (!session.isBot(playerId) || actionSnapshots.capture(playerId).phase() != PlayerActionPhase.REACTION) {
                 continue;
@@ -68,7 +69,7 @@ final class GbBotStrategy implements BotStrategy {
     }
 
     private void handleGbReaction(MahjongTableSession session, UUID playerId) {
-        PlayerActionSnapshot snapshot = new PlayerActionSnapshotFactory(session).capture(playerId);
+        PlayerActionSnapshot snapshot = session.actionSnapshotFactory().capture(playerId);
         if (snapshot.phase() != PlayerActionPhase.REACTION) {
             return;
         }
@@ -79,7 +80,7 @@ final class GbBotStrategy implements BotStrategy {
         if (!session.isStarted() || session.hasPendingReaction() || !Objects.equals(session.playerAt(session.currentSeat()), playerId)) {
             return;
         }
-        PlayerActionSnapshot snapshot = new PlayerActionSnapshotFactory(session).capture(playerId);
+        PlayerActionSnapshot snapshot = session.actionSnapshotFactory().capture(playerId);
         if (snapshot.phase() != PlayerActionPhase.TURN) {
             return;
         }
@@ -128,7 +129,12 @@ final class GbBotStrategy implements BotStrategy {
     }
 
     private boolean hasAction(PlayerActionSnapshot snapshot, PlayerActionId actionId) {
-        return snapshot.actions().stream().anyMatch(action -> action.actionId() == actionId);
+        for (PlayerActionEntry action : snapshot.actions()) {
+            if (action.actionId() == actionId) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void scheduleGbTurnRetry(MahjongTableSession session, UUID playerId, int retryAttempts, String reason) {

--- a/src/main/java/top/ellan/mahjong/table/runtime/SichuanBotStrategy.java
+++ b/src/main/java/top/ellan/mahjong/table/runtime/SichuanBotStrategy.java
@@ -43,7 +43,7 @@ final class SichuanBotStrategy implements BotStrategy {
         if (!session.isStarted()) {
             return;
         }
-        PlayerActionSnapshotFactory actionSnapshotFactory = new PlayerActionSnapshotFactory(session);
+        PlayerActionSnapshotFactory actionSnapshotFactory = session.actionSnapshotFactory();
         for (UUID playerId : session.players()) {
             if (!session.isBot(playerId)) {
                 continue;

--- a/src/test/kotlin/top/ellan/mahjong/table/runtime/BotActionSchedulerTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/runtime/BotActionSchedulerTest.kt
@@ -16,6 +16,7 @@ import top.ellan.mahjong.model.MahjongVariant
 import top.ellan.mahjong.model.SeatWind
 import top.ellan.mahjong.runtime.PluginTask
 import top.ellan.mahjong.runtime.ServerScheduler
+import top.ellan.mahjong.table.action.PlayerActionSnapshotFactory
 import top.ellan.mahjong.table.core.MahjongTableSession
 import top.ellan.mahjong.table.core.TableRuntimeServices
 import java.util.UUID
@@ -33,6 +34,7 @@ class BotActionSchedulerTest {
     @Test
     fun `non riichi variant uses gb style bot scheduling`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -58,6 +60,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot turn falls back to selectable discard index`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -96,6 +99,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot exposes a flower before considering kan or discard`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -131,6 +135,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot turn stops retrying after max attempts`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -188,6 +193,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot turn retries reset on next scheduling cycle`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -252,6 +258,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan variant uses sichuan bot strategy`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -280,6 +287,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot exchange preparation uses short delay and one batched submission`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -328,6 +336,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot dingque preparation uses short delay`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -368,6 +377,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot prioritises discarding from smallest suit when all three suits present`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -419,6 +429,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot delegates to engine when already missing one suit`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -468,6 +479,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot declares tsumo when possible`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -502,6 +514,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot reaction uses gb suggested reaction`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)

--- a/src/test/kotlin/top/ellan/mahjong/table/runtime/SichuanBotPreparationSchedulerTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/runtime/SichuanBotPreparationSchedulerTest.kt
@@ -13,6 +13,7 @@ import top.ellan.mahjong.model.MahjongVariant
 import top.ellan.mahjong.model.SeatWind
 import top.ellan.mahjong.runtime.PluginTask
 import top.ellan.mahjong.runtime.ServerScheduler
+import top.ellan.mahjong.table.action.PlayerActionSnapshotFactory
 import top.ellan.mahjong.table.core.MahjongTableSession
 import top.ellan.mahjong.table.core.TableRuntimeServices
 import java.util.UUID
@@ -22,6 +23,7 @@ class SichuanBotPreparationSchedulerTest {
     @Test
     fun `dealer bot waits without retries while human dingque is pending`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val center = mock(Location::class.java)
@@ -62,6 +64,7 @@ class SichuanBotPreparationSchedulerTest {
     @Test
     fun `preparation still schedules pending bot after pending human`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -91,6 +94,7 @@ class SichuanBotPreparationSchedulerTest {
     @Test
     fun `stale turn task exits during preparation without retry`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)


### PR DESCRIPTION
## Summary
Spark 采样（https://spark.lucko.me/j9YE2XtMP3）显示每 tick 观众渲染大量时间花在 `LocalizedMessages.plain` 的 MiniMessage 反序列化（`renderWithTags`/`deserialize` 热点，`MessageService.plain` 栈）与 G1 分配（`allocate_new_tlab` 热点）上。

三个改动（行为不变）：
1. **Map 版渲染缓存**：`LocalizedMessages.render/plain(Locale, key, Map)` 现按 `(locale, key, 排序后的占位符条目)` 用 Caffeine（max 512）缓存；热路径 `publicSeatStatus`/`publicCenterText`/`botDisplayName` 每 tick 只对稳定占位符集反序列化一次。占位符按 tag 名解析，Map 迭代顺序不影响输出；bundle 加载后不可变。
2. **MessageService 门面补齐**：`render/plain(Locale, key, Map)` + `formatNumber` 委托，热调用方无需构造 TagResolver 数组。
3. **PlayerActionSnapshotFactory 复用**：每 session 一个（原先 GbBot 每 tick new 3 次 + Sichuan 1 次），`GbBotStrategy.hasAction` stream → for 循环。

## 门禁
性能 label：`performance-ab` + `performance-i18n`（i18n profile 为 PR-A #126 新增，含 bot-name / seat-status / center-text 等带占位符渲染基准）。

## Test plan
- [x] 本地 `compileJava`（JDK 25 toolchain）通过
- [x] 本地 i18n + BotStrategy 测试通过（`-PmahjongJavaTarget=25`，getFirst 需要 Java 21+ API）
- [ ] CI test.yml 全量
- [ ] i18n 权威 A/B 门禁 PASS_OPTIMIZED