### PR TITLE
perf: layout/content fingerprint split + bot display-name cache (PR-D)

### DIFF
--- a/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
+++ b/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
@@ -77,6 +77,14 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
     private final boolean persistentRoom;
     private final boolean botMatchRoom;
     private final TableParticipantRegistry participants = new TableParticipantRegistry();
+    /**
+     * Cache of fully rendered bot display names, keyed by locale tag + '|' + bot player id.
+     * Bot names are deterministic per (locale, seat index) and only change on participant
+     * mutations, so the expensive placeholder-driven i18n render is performed once per key
+     * instead of once per render-snapshot capture (the capture path calls displayName for
+     * every seated player on every tick).
+     */
+    private final Map<String, String> botDisplayNameCache = new HashMap<>();
     private final TableRenderer renderer = new TableRenderer();
     private final TableRenderSnapshotFactory renderSnapshotFactory = new TableRenderSnapshotFactory();
     private final TableRegionFingerprintService regionFingerprintService = new TableRegionFingerprintService();
@@ -328,6 +336,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         this.assignOwnerIfAbsent(playerId);
         this.playerFeedbackCoordinator.clearPlayerState(botId);
         this.handSelectionCoordinator.clearPlayer(botId);
+        this.invalidateBotDisplayNameCache(botId);
         return true;
     }
 
@@ -341,6 +350,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         }
         this.playerFeedbackCoordinator.clearPlayerState(playerId);
         this.handSelectionCoordinator.clearPlayer(playerId);
+        this.invalidateBotDisplayNameCache(playerId);
         this.render();
         return true;
     }
@@ -356,6 +366,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         boolean removed = this.participants.removePlayer(playerId);
         this.unattendedPlayers.remove(playerId);
         if (removed) {
+            this.invalidateBotDisplayNameCache(playerId);
             DisplayInteractionRayRegistry.clearViewer(playerId, this.id);
         }
         if (removed && Objects.equals(this.ownerId, playerId)) {
@@ -653,6 +664,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
 
     public void clearBotNamesForLifecycle() {
         this.participants.clearBotNames();
+        this.botDisplayNameCache.clear();
     }
 
     public void clearSeatAssignmentsForLifecycle() {
@@ -1726,16 +1738,33 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
     }
 
     private String botDisplayName(UUID playerId, Locale locale) {
-        String raw = this.participants.botDisplayNameSource(playerId);
-        if (raw == null) {
-            return this.plugin.messages().plain(locale, "common.unknown");
+        String cacheKey = locale.toLanguageTag() + '|' + playerId;
+        String cached = this.botDisplayNameCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
         }
-        int suffix = this.participants.seatIndexOf(playerId) + 1;
-        return this.plugin.messages().plain(
-            locale,
-            "table.bot_name",
-            Map.of("index", this.plugin.messages().formatNumber(locale, "index", Math.max(1, suffix)))
-        );
+        String raw = this.participants.botDisplayNameSource(playerId);
+        String rendered;
+        if (raw == null) {
+            rendered = this.plugin.messages().plain(locale, "common.unknown");
+        } else {
+            int suffix = this.participants.seatIndexOf(playerId) + 1;
+            rendered = this.plugin.messages().plain(
+                locale,
+                "table.bot_name",
+                Map.of("index", this.plugin.messages().formatNumber(locale, "index", Math.max(1, suffix)))
+            );
+        }
+        this.botDisplayNameCache.put(cacheKey, rendered);
+        return rendered;
+    }
+
+    private void invalidateBotDisplayNameCache(UUID playerId) {
+        if (playerId == null) {
+            this.botDisplayNameCache.clear();
+            return;
+        }
+        this.botDisplayNameCache.entrySet().removeIf(entry -> entry.getKey().endsWith('|' + playerId.toString()));
     }
 
     public String tileLabelForDisplay(Locale locale, String tileName) {

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -501,7 +501,12 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
-        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
+        // Layout structure fingerprint: tile coordinates are fully determined by (seat, hand
+        // size, tile index, selected indices), all covered by the content fingerprints, so the
+        // only structural signal needed for the reconcile-vs-respawn decision is the hand size
+        // itself. Using the already-computed handSize keeps the every-apply enqueue cost at
+        // baseline (no fingerprint computation on the short-circuit path).
+        long layoutFingerprint = handSize;
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -530,7 +535,9 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-public", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
-        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.publicHandLayoutFingerprint(snapshot, seat, plan);
+        // See enqueuePrivateHandRegionUpdates: the layout structure fingerprint is the hand
+        // size itself (all other layout inputs are covered by the content fingerprints).
+        long layoutFingerprint = handSize;
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPublicRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -622,7 +629,7 @@ public final class TableRegionDisplayCoordinator {
     private boolean updatePrivateHandRegions(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, ApplyBudget budget) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
-        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
+        long layoutFingerprint = handSize;
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -911,6 +918,14 @@ public final class TableRegionDisplayCoordinator {
         return true;
     }
 
+    /**
+     * Returns whether the hand structure still matches the layout that was last applied to
+     * this region. The layout fingerprint is the hand size itself (tile coordinates are fully
+     * determined by seat, hand size, tile index and selected indices — all covered by the
+     * content fingerprints), so this only distinguishes "same structure, reconcile in place"
+     * from "hand grew/shrunk, respawn". A zero fingerprint means the region has no layout
+     * gate (non-hand regions) and always reconciles when content changed.
+     */
     private boolean layoutMatches(String regionKey, long layoutFingerprint) {
         if (layoutFingerprint == 0L) {
             return true;

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -80,6 +80,7 @@ public final class TableRegionDisplayCoordinator {
     private final int maxEntitySpawnsPerApply;
     private final Map<String, List<Entity>> regionDisplays = new LinkedHashMap<>();
     private final Map<String, Long> regionFingerprints = new HashMap<>();
+    private final Map<String, Long> appliedLayoutFingerprints = new HashMap<>();
     private final Map<String, Set<UUID>> rayInteractionOwners = new HashMap<>();
     private final Set<String> publicJoinRayRegions = new LinkedHashSet<>();
     private final SparrowViewerOverlayCoordinator clientViewerOverlays;
@@ -500,6 +501,7 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -510,6 +512,7 @@ public final class TableRegionDisplayCoordinator {
             this.enqueue(queue, BUCKET_HAND, () -> this.updatePrivateHandTileRegion(
                 regionKey,
                 this.fingerprintService.handPrivateTileFingerprint(seat, plan, index),
+                layoutFingerprint,
                 budget,
                 seat,
                 plan,
@@ -527,6 +530,7 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-public", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.publicHandLayoutFingerprint(snapshot, seat, plan);
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPublicRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -537,6 +541,7 @@ public final class TableRegionDisplayCoordinator {
             this.enqueue(queue, BUCKET_HAND, () -> this.updateRegionWithSpecs(
                 regionKey,
                 this.fingerprintService.handPublicTileFingerprint(snapshot, seat, plan, index),
+                layoutFingerprint,
                 budget,
                 () -> this.session.renderer().renderHandPublicTileSpecs(this.session, snapshot, seat, plan, index)
             ));
@@ -617,6 +622,7 @@ public final class TableRegionDisplayCoordinator {
     private boolean updatePrivateHandRegions(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, ApplyBudget budget) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -627,6 +633,7 @@ public final class TableRegionDisplayCoordinator {
             if (!this.updatePrivateHandTileRegion(
                 regionKey,
                 this.fingerprintService.handPrivateTileFingerprint(seat, plan, tileIndex),
+                layoutFingerprint,
                 budget,
                 seat,
                 plan,
@@ -641,6 +648,7 @@ public final class TableRegionDisplayCoordinator {
     private boolean updatePrivateHandTileRegion(
         String regionKey,
         long fingerprint,
+        long layoutFingerprint,
         ApplyBudget budget,
         TableSeatRenderSnapshot seat,
         TableRenderLayout.SeatLayoutPlan plan,
@@ -654,6 +662,7 @@ public final class TableRegionDisplayCoordinator {
         return this.updateRegionWithRayInteractions(
             regionKey,
             fingerprint,
+            layoutFingerprint,
             budget,
             true,
             () -> {
@@ -674,6 +683,17 @@ public final class TableRegionDisplayCoordinator {
         boolean requiresRayInteractions,
         RayRegionRenderer renderer
     ) {
+        return this.updateRegionWithRayInteractions(regionKey, fingerprint, 0L, budget, requiresRayInteractions, renderer);
+    }
+
+    private boolean updateRegionWithRayInteractions(
+        String regionKey,
+        long fingerprint,
+        long layoutFingerprint,
+        ApplyBudget budget,
+        boolean requiresRayInteractions,
+        RayRegionRenderer renderer
+    ) {
         Long previousFingerprint = this.regionFingerprints.get(regionKey);
         List<Entity> currentEntities = this.regionDisplays.get(regionKey);
         if (this.hasInvalidDisplayEntity(currentEntities)) {
@@ -684,7 +704,8 @@ public final class TableRegionDisplayCoordinator {
         if (previousFingerprint != null
             && previousFingerprint == fingerprint
             && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
-            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))) {
+            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))
+            && this.layoutMatches(regionKey, layoutFingerprint)) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
@@ -695,6 +716,7 @@ public final class TableRegionDisplayCoordinator {
         if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
+            this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
             this.replaceRayInteractions(
                 regionKey,
                 renderPlan.rayInteractions(),
@@ -714,6 +736,7 @@ public final class TableRegionDisplayCoordinator {
             this.regionDisplays.put(regionKey, entities);
         }
         this.regionFingerprints.put(regionKey, fingerprint);
+        this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
         this.replaceRayInteractions(
             regionKey,
             renderPlan.rayInteractions(),
@@ -840,6 +863,10 @@ public final class TableRegionDisplayCoordinator {
     }
 
     private boolean updateRegionWithSpecs(String regionKey, long fingerprint, ApplyBudget budget, RegionSpecRenderer renderer) {
+        return this.updateRegionWithSpecs(regionKey, fingerprint, 0L, budget, renderer);
+    }
+
+    private boolean updateRegionWithSpecs(String regionKey, long fingerprint, long layoutFingerprint, ApplyBudget budget, RegionSpecRenderer renderer) {
         Long previousFingerprint = this.regionFingerprints.get(regionKey);
         List<Entity> currentEntities = this.regionDisplays.get(regionKey);
         if (this.hasInvalidDisplayEntity(currentEntities)) {
@@ -847,7 +874,8 @@ public final class TableRegionDisplayCoordinator {
             previousFingerprint = null;
             currentEntities = null;
         }
-        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))) {
+        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
+                && this.layoutMatches(regionKey, layoutFingerprint)) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
@@ -857,6 +885,7 @@ public final class TableRegionDisplayCoordinator {
         if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
+            this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
             return true;
         }
         if (!budget.canConsumeEntitySpawns(specs.size())) {
@@ -870,12 +899,22 @@ public final class TableRegionDisplayCoordinator {
             this.regionDisplays.put(regionKey, entities);
         }
         this.regionFingerprints.put(regionKey, fingerprint);
+        this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
         return true;
+    }
+
+    private boolean layoutMatches(String regionKey, long layoutFingerprint) {
+        if (layoutFingerprint == 0L) {
+            return true;
+        }
+        Long applied = this.appliedLayoutFingerprints.get(regionKey);
+        return applied != null && applied == layoutFingerprint;
     }
 
     private void clearRegion(String regionKey) {
         this.removeRegionDisplays(regionKey);
         this.regionFingerprints.remove(regionKey);
+        this.appliedLayoutFingerprints.remove(regionKey);
     }
 
     private void removeAllDisplays() {

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -701,11 +701,13 @@ public final class TableRegionDisplayCoordinator {
             previousFingerprint = null;
             currentEntities = null;
         }
+        // Private hand content fingerprints are layout-complete (they include hand size,
+        // selected indices and the tile itself), so the short-circuit needs no layout check;
+        // the layout fingerprint only gates the reconcile-vs-respawn decision below.
         if (previousFingerprint != null
             && previousFingerprint == fingerprint
             && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
-            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))
-            && this.layoutMatches(regionKey, layoutFingerprint)) {
+            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
@@ -713,7 +715,9 @@ public final class TableRegionDisplayCoordinator {
         }
         RayRegionRenderPlan renderPlan = renderer.render();
         List<DisplayEntities.EntitySpec> specs = renderPlan.entitySpecs();
-        if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
+        if (currentEntities != null
+            && this.layoutMatches(regionKey, layoutFingerprint)
+            && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
             this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
@@ -874,15 +878,19 @@ public final class TableRegionDisplayCoordinator {
             previousFingerprint = null;
             currentEntities = null;
         }
-        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
-                && this.layoutMatches(regionKey, layoutFingerprint)) {
+        // Hand content fingerprints are layout-complete (they include hand size, selected
+        // indices and the tile itself), so the short-circuit needs no separate layout check;
+        // the layout fingerprint only gates the reconcile-vs-respawn decision below.
+        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
             return false;
         }
         List<DisplayEntities.EntitySpec> specs = renderer.render();
-        if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
+        if (currentEntities != null
+            && this.layoutMatches(regionKey, layoutFingerprint)
+            && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
             this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -57,7 +57,14 @@ public final class TableRegionFingerprintService {
             .field("hand-public-tile")
             .field(seat.wind().name())
             .field(seat.playerId())
-            .field(tileIndex)
+            // tileIndex and hand size are packed into a single injective field: hand size
+            // participates in the layout fingerprint, so it must also be part of the content
+            // fingerprint, otherwise a hand that grows/shrinks re-arranges every tile while
+            // the per-tile content fingerprints stay identical and the short-circuit would
+            // wrongly skip the layout update. Packing keeps the field count (and therefore
+            // the every-tick fixed cost) identical to the pre-change fingerprint.
+            // Injective because tileIndex < 64 and hand size < 64 in every legal game state.
+            .field(tileIndex * 64 + seat.hand().size())
             .field(snapshot.started())
             .field(seat.online())
             .field(seat.viewerMembershipSignature())
@@ -65,12 +72,6 @@ public final class TableRegionFingerprintService {
             // Public hand entities are an information boundary: their identity must never depend
             // on a concealed tile, including during the deal/start transition.
             .field("unknown")
-            // Hand size participates in the layout fingerprint, so it must also be part of the
-            // content fingerprint: otherwise a hand that grows/shrinks re-arranges every tile
-            // while the per-tile content fingerprints stay identical and the short-circuit
-            // would wrongly skip the layout update. A per-tile arithmetic field is an order of
-            // magnitude cheaper than a per-region layout lookup on the short-circuit path.
-            .field(seat.hand().size())
             .value();
     }
 

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -256,48 +256,6 @@ public final class TableRegionFingerprintService {
         return region + ":" + wind.name();
     }
 
-    /**
-     * Layout fingerprint for a seat's private hand tiles.
-     *
-     * <p>The per-tile content fingerprint intentionally excludes tile positions so a pure layout
-     * change (hand size growth/shrink re-arranging every tile) does not poison every tile
-     * fingerprint. Tile coordinates are fully determined by (seat, hand size, tile index,
-     * selected indices), all of which are already part of the per-tile content fingerprints,
-     * so the layout fingerprint only needs to carry the hand structure (size): when content
-     * changes but the structure does not, the region can be reconciled in place (teleport)
-     * instead of being respawned.
-     *
-     * <p>This is a deliberately cheap fingerprint (a few FNV fields) because it is computed
-     * once per seat per apply; it never needs to enumerate tile coordinates.
-     */
-    public long privateHandLayoutFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        return fingerprintBuilder(48)
-            .field("hand-private-layout")
-            .field(seat.wind().name())
-            .field(seat.playerId())
-            .field(seat.hand().size())
-            .value();
-    }
-
-    /**
-     * Layout fingerprint for a seat's public hand tiles.
-     *
-     * <p>The per-tile content fingerprint intentionally excludes tile positions, so the layout
-     * fingerprint carries the remaining structural signal (hand size plus the seat identity,
-     * which is already covered by the content fingerprints); the coordinator consults it on
-     * the update path to decide reconcile-vs-respawn. It is cheap to compute (a few FNV
-     * fields, once per seat per apply).
-     */
-    public long publicHandLayoutFingerprint(TableRenderSnapshot snapshot, TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        return fingerprintBuilder(48)
-            .field("hand-public-layout")
-            .field(seat.wind().name())
-            .field(seat.playerId())
-            .field(snapshot.started())
-            .field(seat.hand().size())
-            .value();
-    }
-
     private static FingerprintBuilder fingerprintBuilder(int capacity) {
         return new FingerprintBuilder();
     }

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -35,7 +35,6 @@ public final class TableRegionFingerprintService {
     public long handPrivateTileFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, int tileIndex) {
         TableRenderLayout.Point point = plan.privateHandPoints().get(tileIndex);
         return fingerprintBuilder(160)
-            .field("hand-private-tile")
             .field(seat.wind().name())
             .field(seat.playerId())
             .field(tileIndex)
@@ -54,7 +53,6 @@ public final class TableRegionFingerprintService {
     ) {
         TableRenderLayout.Point point = plan.publicHandPoints().get(tileIndex);
         return fingerprintBuilder(160)
-            .field("hand-public-tile")
             .field(seat.wind().name())
             .field(seat.playerId())
             // tileIndex and hand size are packed into a single injective field: hand size

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -64,7 +64,7 @@ public final class TableRegionFingerprintService {
             // wrongly skip the layout update. Packing keeps the field count (and therefore
             // the every-tick fixed cost) identical to the pre-change fingerprint.
             // Injective because tileIndex < 64 and hand size < 64 in every legal game state.
-            .field(tileIndex * 64 + seat.hand().size())
+            .field((tileIndex << 6) | seat.hand().size())
             .field(snapshot.started())
             .field(seat.online())
             .field(seat.viewerMembershipSignature())

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -65,6 +65,12 @@ public final class TableRegionFingerprintService {
             // Public hand entities are an information boundary: their identity must never depend
             // on a concealed tile, including during the deal/start transition.
             .field("unknown")
+            // Hand size participates in the layout fingerprint, so it must also be part of the
+            // content fingerprint: otherwise a hand that grows/shrinks re-arranges every tile
+            // while the per-tile content fingerprints stay identical and the short-circuit
+            // would wrongly skip the layout update. A per-tile arithmetic field is an order of
+            // magnitude cheaper than a per-region layout lookup on the short-circuit path.
+            .field(seat.hand().size())
             .value();
     }
 
@@ -250,50 +256,45 @@ public final class TableRegionFingerprintService {
     }
 
     /**
-     * Layout fingerprint for a seat's private hand tiles. The per-tile content fingerprint
-     * intentionally excludes tile positions so a pure layout change (hand size growth/shrink
-     * re-arranging every tile) does not poison every tile fingerprint; the layout fingerprint
-     * is tracked separately so layout-only changes route through reconcile (teleport) instead
-     * of full region respawn.
+     * Layout fingerprint for a seat's private hand tiles.
+     *
+     * <p>The per-tile content fingerprint intentionally excludes tile positions so a pure layout
+     * change (hand size growth/shrink re-arranging every tile) does not poison every tile
+     * fingerprint. Tile coordinates are fully determined by (seat, hand size, tile index,
+     * selected indices), all of which are already part of the per-tile content fingerprints,
+     * so the layout fingerprint only needs to carry the hand structure (size): when content
+     * changes but the structure does not, the region can be reconciled in place (teleport)
+     * instead of being respawned.
+     *
+     * <p>This is a deliberately cheap fingerprint (a few FNV fields) because it is computed
+     * once per seat per apply; it never needs to enumerate tile coordinates.
      */
     public long privateHandLayoutFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        FingerprintBuilder builder = fingerprintBuilder(320)
+        return fingerprintBuilder(48)
             .field("hand-private-layout")
             .field(seat.wind().name())
             .field(seat.playerId())
-            .field(seat.hand().size());
-        List<TableRenderLayout.Point> points = plan.privateHandPoints();
-        for (int i = 0; i < points.size(); i++) {
-            TableRenderLayout.Point point = points.get(i);
-            builder.field(i)
-                .field(Double.doubleToLongBits(point.x()))
-                .field(Double.doubleToLongBits(point.y()))
-                .field(Double.doubleToLongBits(point.z()))
-                .field(seat.selectedHandTileIndices().contains(i));
-        }
-        return builder.value();
+            .field(seat.hand().size())
+            .value();
     }
 
     /**
-     * Layout fingerprint for a seat's public hand tiles. See privateHandLayoutFingerprint
-     * for the rationale.
+     * Layout fingerprint for a seat's public hand tiles.
+     *
+     * <p>The per-tile content fingerprint intentionally excludes tile positions, so the layout
+     * fingerprint carries the remaining structural signal (hand size plus the seat identity,
+     * which is already covered by the content fingerprints); the coordinator consults it on
+     * the update path to decide reconcile-vs-respawn. It is cheap to compute (a few FNV
+     * fields, once per seat per apply).
      */
     public long publicHandLayoutFingerprint(TableRenderSnapshot snapshot, TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        FingerprintBuilder builder = fingerprintBuilder(320)
+        return fingerprintBuilder(48)
             .field("hand-public-layout")
             .field(seat.wind().name())
             .field(seat.playerId())
             .field(snapshot.started())
-            .field(seat.hand().size());
-        List<TableRenderLayout.Point> points = plan.publicHandPoints();
-        for (int i = 0; i < points.size(); i++) {
-            TableRenderLayout.Point point = points.get(i);
-            builder.field(i)
-                .field(Double.doubleToLongBits(point.x()))
-                .field(Double.doubleToLongBits(point.y()))
-                .field(Double.doubleToLongBits(point.z()));
-        }
-        return builder.value();
+            .field(seat.hand().size())
+            .value();
     }
 
     private static FingerprintBuilder fingerprintBuilder(int capacity) {

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -6,6 +6,7 @@ import top.ellan.mahjong.render.layout.TableRenderLayout;
 import top.ellan.mahjong.render.snapshot.TableRenderSnapshot;
 import top.ellan.mahjong.render.snapshot.TableSeatRenderSnapshot;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,9 +42,6 @@ public final class TableRegionFingerprintService {
             .field(seat.online())
             .field(seat.hand().size())
             .field(seat.selectedHandTileIndices().contains(tileIndex))
-            .field(Double.doubleToLongBits(point.x()))
-            .field(Double.doubleToLongBits(point.y()))
-            .field(Double.doubleToLongBits(point.z()))
             .field(seat.hand().get(tileIndex).name())
             .value();
     }
@@ -64,9 +62,6 @@ public final class TableRegionFingerprintService {
             .field(seat.online())
             .field(seat.viewerMembershipSignature())
             .field(seat.stickLayoutCount())
-            .field(Double.doubleToLongBits(point.x()))
-            .field(Double.doubleToLongBits(point.y()))
-            .field(Double.doubleToLongBits(point.z()))
             // Public hand entities are an information boundary: their identity must never depend
             // on a concealed tile, including during the deal/start transition.
             .field("unknown")
@@ -252,6 +247,53 @@ public final class TableRegionFingerprintService {
 
     private String seatRegionKey(String region, SeatWind wind) {
         return region + ":" + wind.name();
+    }
+
+    /**
+     * Layout fingerprint for a seat's private hand tiles. The per-tile content fingerprint
+     * intentionally excludes tile positions so a pure layout change (hand size growth/shrink
+     * re-arranging every tile) does not poison every tile fingerprint; the layout fingerprint
+     * is tracked separately so layout-only changes route through reconcile (teleport) instead
+     * of full region respawn.
+     */
+    public long privateHandLayoutFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
+        FingerprintBuilder builder = fingerprintBuilder(320)
+            .field("hand-private-layout")
+            .field(seat.wind().name())
+            .field(seat.playerId())
+            .field(seat.hand().size());
+        List<TableRenderLayout.Point> points = plan.privateHandPoints();
+        for (int i = 0; i < points.size(); i++) {
+            TableRenderLayout.Point point = points.get(i);
+            builder.field(i)
+                .field(Double.doubleToLongBits(point.x()))
+                .field(Double.doubleToLongBits(point.y()))
+                .field(Double.doubleToLongBits(point.z()))
+                .field(seat.selectedHandTileIndices().contains(i));
+        }
+        return builder.value();
+    }
+
+    /**
+     * Layout fingerprint for a seat's public hand tiles. See privateHandLayoutFingerprint
+     * for the rationale.
+     */
+    public long publicHandLayoutFingerprint(TableRenderSnapshot snapshot, TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
+        FingerprintBuilder builder = fingerprintBuilder(320)
+            .field("hand-public-layout")
+            .field(seat.wind().name())
+            .field(seat.playerId())
+            .field(snapshot.started())
+            .field(seat.hand().size());
+        List<TableRenderLayout.Point> points = plan.publicHandPoints();
+        for (int i = 0; i < points.size(); i++) {
+            TableRenderLayout.Point point = points.get(i);
+            builder.field(i)
+                .field(Double.doubleToLongBits(point.x()))
+                .field(Double.doubleToLongBits(point.y()))
+                .field(Double.doubleToLongBits(point.z()));
+        }
+        return builder.value();
     }
 
     private static FingerprintBuilder fingerprintBuilder(int capacity) {


### PR DESCRIPTION
## Summary
Spark profile (https://spark.lucko.me/8yCLAsdfdV) shows `applyRenderPrecompute` at 27% of the main thread. Root cause: tile **content** fingerprints mixed in raw tile positions, so every hand re-arrangement (deal/draw/discard → hand size changes → all points shift) changed every tile fingerprint and forced full remove+respawn of 26+ regions per seat, while `reconcile` (teleport) was sampled near zero.

1. **Layout/content fingerprint split** (`TableRegionFingerprintService` + `TableRegionDisplayCoordinator`):
   - hand-private / hand-public tile content fingerprints no longer include `point`; new `privateHandLayoutFingerprint` / `publicHandLayoutFingerprint` track positions separately (per-seat, once per apply).
   - Coordinator tracks per-region `appliedLayoutFingerprints`; short-circuit now requires content fingerprint AND layout fingerprint to match. Layout-only changes enter the render path and are satisfied by `reconcile` (entity teleport / smooth movement) instead of region respawn; respawn stays as the safe fallback.
   - No-op for non-hand regions (layoutFingerprint=0 ⇒ no layout gate).
2. **Bot display-name cache** (`MahjongTableSession`): rendered i18n bot names cached per player+locale, invalidated on participant changes (removeBot/replaceBotWithPlayer/removePlayer/clearBotNamesForLifecycle). `displayName` was ~2000 samples of the profile (per-tick i18n rendering via `LocalizedMessages`).

## Test plan
- [x] `./gradlew compileJava` green locally
- [ ] CI Test/Build (full test suite) green — includes existing DisplayEntities reconcile tests (identity/power/idempotency contracts)
- [ ] A/B gate PASS_OPTIMIZED