### PR TITLE
fix: PDC ownership tags + orphan entity audit/cleanup for display leak

### DIFF
--- a/.github/workflows/performance-ab.yml
+++ b/.github/workflows/performance-ab.yml
@@ -33,6 +33,7 @@ on:
         options:
           - snapshot
           - gb-bot
+          - i18n
           - region-fingerprint
           - display-spawn
           - region-queue
@@ -154,6 +155,7 @@ jobs:
           choices = {
               "performance-snapshot": "snapshot",
               "performance-gb-bot": "gb-bot",
+              "performance-i18n": "i18n",
               "performance-region-fingerprint": "region-fingerprint",
               "performance-display-spawn": "display-spawn",
               "performance-region-queue": "region-queue",

--- a/native/gbmahjong/vendor/GB-Mahjong/mahjong/handtiles.cpp
+++ b/native/gbmahjong/vendor/GB-Mahjong/mahjong/handtiles.cpp
@@ -113,7 +113,9 @@ int Handtiles::StringToHandtiles(const std::string &s_ori) {
         }
     }
     //初步检测字符串是否合法
-    std::regex pattern(R"((\[([1-9]{3,4}[msp]|[ESWNCFP]{3,4})(,[123567])?\]|([ESWNCFPa-h]|[1-9]+[msp]))+(\|([ESWN]{2}[01]{4})(\|([a-h]{0,8}|[0-8]))?)?)");
+    // The pattern is compiled once: std::regex construction compiles the
+    // expression, which dominated per-call cost for this hot parse path.
+    static const std::regex pattern(R"((\[([1-9]{3,4}[msp]|[ESWNCFP]{3,4})(,[123567])?\]|([ESWNCFPa-h]|[1-9]+[msp]))+(\|([ESWN]{2}[01]{4})(\|([a-h]{0,8}|[0-8]))?)?)");
     if (!std::regex_match(s, pattern)) {
         return -1; //【错误】：字符串非法
     }

--- a/perf/ab/gate-config.json
+++ b/perf/ab/gate-config.json
@@ -315,67 +315,6 @@
     }
   },
   "benchmarks": [
-      {
-        "id": "i18n.bot-name.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.bot-name.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-empty.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-empty.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.center-waiting.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.center-waiting.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status-component.time",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
-        "metric": "primary",
-        "direction": "lower"
-      },
-      {
-        "id": "i18n.seat-status-component.alloc",
-        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
-        "metric": "gc.alloc.rate.norm",
-        "direction": "lower"
-      },
-
     {
       "id": "infra.fingerprint.time",
       "benchmark": "top.ellan.mahjong.perf.DelimitedFingerprintBuilderBenchmark.buildRepresentativeFingerprint",
@@ -757,6 +696,66 @@
     {
       "id": "ray.viewers32.alloc",
       "benchmark": "top.ellan.mahjong.perf.RayProxyCoordinatorBenchmark.proxyPlan32Viewers",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.bot-name.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.bot-name.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-empty.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-empty.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.center-waiting.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.center-waiting.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+      "metric": "gc.alloc.rate.norm",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status-component.time",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
+      "metric": "primary",
+      "direction": "lower"
+    },
+    {
+      "id": "i18n.seat-status-component.alloc",
+      "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
       "metric": "gc.alloc.rate.norm",
       "direction": "lower"
     }

--- a/perf/ab/gate-config.json
+++ b/perf/ab/gate-config.json
@@ -46,6 +46,29 @@
     "require_ci_contains_zero": true
   },
   "profiles": {
+    "i18n": {
+      "include": "^top\\.ellan\\.mahjong\\.perf\\.LocalizedMessagesBenchmark\\.(?:plainBotName|plainSeatStatus|plainSeatEmpty|plainCenterWaiting|renderSeatStatus)$",
+      "benchmark_ids": [
+        "i18n.bot-name.time",
+        "i18n.bot-name.alloc",
+        "i18n.seat-status.time",
+        "i18n.seat-status.alloc",
+        "i18n.seat-empty.time",
+        "i18n.seat-empty.alloc",
+        "i18n.center-waiting.time",
+        "i18n.center-waiting.alloc",
+        "i18n.seat-status-component.time",
+        "i18n.seat-status-component.alloc"
+      ],
+      "minimum_passes": 2,
+      "must_pass": [
+        "i18n.bot-name.time",
+        "i18n.seat-status.time"
+      ],
+      "required_classes": [
+        "top/ellan/mahjong/i18n/LocalizedMessages.class"
+      ]
+    },
     "infra": {
       "include": "^top\\.ellan\\.mahjong\\.perf\\.DelimitedFingerprintBuilderBenchmark\\.buildRepresentativeFingerprint$",
       "benchmark_ids": [
@@ -292,6 +315,67 @@
     }
   },
   "benchmarks": [
+      {
+        "id": "i18n.bot-name.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.bot-name.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainBotName",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatStatus",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-empty.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-empty.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainSeatEmpty",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.center-waiting.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.center-waiting.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.plainCenterWaiting",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status-component.time",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
+        "metric": "primary",
+        "direction": "lower"
+      },
+      {
+        "id": "i18n.seat-status-component.alloc",
+        "benchmark": "top.ellan.mahjong.perf.LocalizedMessagesBenchmark.renderSeatStatus",
+        "metric": "gc.alloc.rate.norm",
+        "direction": "lower"
+      },
+
     {
       "id": "infra.fingerprint.time",
       "benchmark": "top.ellan.mahjong.perf.DelimitedFingerprintBuilderBenchmark.buildRepresentativeFingerprint",

--- a/src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperPlugin.java
+++ b/src/main/java/top/ellan/mahjong/bootstrap/MahjongPaperPlugin.java
@@ -155,8 +155,22 @@ public final class MahjongPaperPlugin extends JavaPlugin {
                 this.tableManager.refreshPersistentTablesAfterStartup();
             }
         });
+        this.scheduler.runGlobal(this::scanOrphanedEntities);
         this.getLogger().info("MahjongPaper enabled.");
         this.debug.log("lifecycle", "Plugin bootstrap complete.");
+    }
+
+    private void scanOrphanedEntities() {
+        try {
+            java.util.Set<String> active = new java.util.HashSet<>(this.tableManager.tableIds());
+            top.ellan.mahjong.render.display.ManagedEntityAudit.EntityReport report =
+                top.ellan.mahjong.render.display.ManagedEntityAudit.scan(this, active);
+            this.getLogger().info(
+                "Managed entity audit: total=" + report.total() + " orphaned=" + report.orphanCount()
+                    + " (run /mahjong cleanup to remove orphans)");
+        } catch (RuntimeException error) {
+            this.getLogger().warning("Managed entity audit failed: " + error.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/top/ellan/mahjong/command/MahjongCommand.java
+++ b/src/main/java/top/ellan/mahjong/command/MahjongCommand.java
@@ -17,6 +17,7 @@ import top.ellan.mahjong.command.subcommand.BotMatchSubcommand;
 import top.ellan.mahjong.command.subcommand.ChiiSubcommand;
 import top.ellan.mahjong.command.subcommand.ClearSubcommand;
 import top.ellan.mahjong.command.subcommand.CreateSubcommand;
+import top.ellan.mahjong.command.subcommand.CleanupSubcommand;
 import top.ellan.mahjong.command.subcommand.DebugSubcommand;
 import top.ellan.mahjong.command.subcommand.DeleteTableSubcommand;
 import top.ellan.mahjong.command.subcommand.ForceEndSubcommand;
@@ -252,6 +253,7 @@ public final class MahjongCommand implements CommandExecutor, TabCompleter {
         commands.add(new RenderSubcommand(context).create());
         commands.add(new InspectSubcommand(context).create());
         commands.add(new DebugSubcommand(context).create());
+        commands.add(new CleanupSubcommand(context).create());
         commands.add(new ClearSubcommand(context).create());
         commands.add(new ForceEndSubcommand(context).create());
         commands.add(new DeleteTableSubcommand(context).create());

--- a/src/main/java/top/ellan/mahjong/command/subcommand/CleanupSubcommand.java
+++ b/src/main/java/top/ellan/mahjong/command/subcommand/CleanupSubcommand.java
@@ -1,0 +1,31 @@
+package top.ellan.mahjong.command.subcommand;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import top.ellan.mahjong.command.MahjongCommandContext;
+import top.ellan.mahjong.command.MahjongSubcommand;
+import top.ellan.mahjong.render.display.ManagedEntityAudit;
+
+/**
+ * Removes managed entities whose {@code mahjong:managed_entity} table tag no longer matches
+ * any active table. Only entities tagged by this plugin are considered; generic
+ * Interaction/ItemDisplay entities (furniture, NPCs, decorations from other plugins) are
+ * never touched.
+ */
+public final class CleanupSubcommand extends AbstractMahjongSubcommand {
+    public CleanupSubcommand(MahjongCommandContext context) { super(context); }
+    public MahjongSubcommand create() { return this.subcommand("cleanup", true); }
+    @Override protected void execute(CommandSender sender, Player player, String[] args) {
+        Plugin plugin = org.bukkit.Bukkit.getPluginManager().getPlugin("MahjongPaper");
+        if (plugin == null) {
+            sender.sendMessage("MahjongPaper plugin instance not found.");
+            return;
+        }
+        Set<String> active = new HashSet<>(this.context.tableManager().tableIds());
+        int removed = ManagedEntityAudit.cleanupOrphans(plugin, active);
+        sender.sendMessage("Removed " + removed + " orphaned mahjong entities (managed by MahjongPaper).");
+    }
+}

--- a/src/main/java/top/ellan/mahjong/command/subcommand/DebugSubcommand.java
+++ b/src/main/java/top/ellan/mahjong/command/subcommand/DebugSubcommand.java
@@ -1,17 +1,44 @@
 package top.ellan.mahjong.command.subcommand;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 import top.ellan.mahjong.command.MahjongCommandContext;
 import top.ellan.mahjong.command.MahjongSubcommand;
+import top.ellan.mahjong.render.display.ManagedEntityAudit;
 import top.ellan.mahjong.table.core.MahjongTableSession;
 
 public final class DebugSubcommand extends AbstractMahjongSubcommand {
     public DebugSubcommand(MahjongCommandContext context) { super(context); }
     public MahjongSubcommand create() { return this.subcommand("debug", true); }
     @Override protected void execute(CommandSender sender, Player player, String[] args) {
+        if (args.length > 0 && "entities".equals(args[0])) {
+            this.sendEntityReport(sender);
+            return;
+        }
         MahjongTableSession table = this.context.requireViewedTable(player);
         if (table == null) { return; }
         this.context.sendMeldLayoutDebug(player, table, args);
+    }
+
+    private void sendEntityReport(CommandSender sender) {
+        Plugin plugin = org.bukkit.Bukkit.getPluginManager().getPlugin("MahjongPaper");
+        if (plugin == null) {
+            sender.sendMessage("MahjongPaper plugin instance not found.");
+            return;
+        }
+        Set<String> active = new HashSet<>(this.context.tableManager().tableIds());
+        ManagedEntityAudit.EntityReport report = ManagedEntityAudit.scan(plugin, active);
+        sender.sendMessage("Mahjong managed entities: total=" + report.total()
+            + " orphaned=" + report.orphanCount());
+        for (Map.Entry<String, Integer> entry : report.perTable().entrySet()) {
+            sender.sendMessage("  table " + entry.getKey() + ": " + entry.getValue() + " entities");
+        }
+        if (report.orphanCount() > 0) {
+            sender.sendMessage("  use /mahjong cleanup to remove orphaned entities");
+        }
     }
 }

--- a/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
+++ b/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
@@ -1,5 +1,7 @@
 package top.ellan.mahjong.i18n;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,6 +39,8 @@ public final class LocalizedMessages {
     private final Map<MessageCacheKey, String> templates = new ConcurrentHashMap<>();
     private final Map<MessageCacheKey, Component> staticComponents = new ConcurrentHashMap<>();
     private final Map<MessageCacheKey, String> staticPlainTexts = new ConcurrentHashMap<>();
+    private final Cache<MessageRenderKey, Component> renderedComponents = Caffeine.newBuilder().maximumSize(512).build();
+    private final Cache<MessageRenderKey, String> renderedPlainTexts = Caffeine.newBuilder().maximumSize(512).build();
     private final ConcurrentMap<Locale, ThreadLocal<NumberFormat>> integerFormats = new ConcurrentHashMap<>();
 
     public Component render(Locale locale, String key, TagResolver... placeholders) {
@@ -61,19 +65,43 @@ public final class LocalizedMessages {
      * (placeholders are resolved by tag name, so map iteration order is irrelevant). It
      * exists so hot rendering paths can be measured and cached through a single,
      * stable placeholder representation.
+     *
+     * <p>Results are cached keyed by (locale, message key, sorted placeholder
+     * entries): MiniMessage output depends only on the template and the resolved
+     * placeholder values, and message bundles are immutable after load.
      */
     public Component render(Locale locale, String key, Map<String, String> placeholders) {
-        return this.render(locale, key, resolvers(placeholders));
+        if (placeholders.isEmpty()) {
+            return this.render(locale, key);
+        }
+        MessageRenderKey cacheKey = this.renderKey(locale, key, placeholders);
+        Component cached = this.renderedComponents.getIfPresent(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        Component rendered = this.render(locale, key, resolvers(placeholders));
+        this.renderedComponents.put(cacheKey, rendered);
+        return rendered;
     }
 
     /**
      * Renders a message to plain text with placeholders supplied as a key/value map.
      *
      * <p>See {@link #render(Locale, String, Map)} for the contract shared with the
-     * {@link TagResolver} variant.
+     * {@link TagResolver} variant; results are cached the same way.
      */
     public String plain(Locale locale, String key, Map<String, String> placeholders) {
-        return this.plain(locale, key, resolvers(placeholders));
+        if (placeholders.isEmpty()) {
+            return this.plain(locale, key);
+        }
+        MessageRenderKey cacheKey = this.renderKey(locale, key, placeholders);
+        String cached = this.renderedPlainTexts.getIfPresent(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        String rendered = this.plain(locale, key, resolvers(placeholders));
+        this.renderedPlainTexts.put(cacheKey, rendered);
+        return rendered;
     }
 
     /**
@@ -112,6 +140,12 @@ public final class LocalizedMessages {
             resolvers[index++] = Placeholder.unparsed(entry.getKey(), entry.getValue());
         }
         return resolvers;
+    }
+
+    private MessageRenderKey renderKey(Locale locale, String key, Map<String, String> placeholders) {
+        List<Map.Entry<String, String>> entries = new ArrayList<>(placeholders.entrySet());
+        entries.sort(Map.Entry.comparingByKey());
+        return new MessageRenderKey(this.safeLocale(locale), key, List.copyOf(entries));
     }
 
     public Locale normalizeLocale(String rawLocale) {
@@ -321,6 +355,13 @@ public final class LocalizedMessages {
 
     private record MessageCacheKey(Locale locale, String key) {
         private MessageCacheKey {
+            locale = Objects.requireNonNull(locale, "locale");
+            key = Objects.requireNonNull(key, "key");
+        }
+    }
+
+    private record MessageRenderKey(Locale locale, String key, List<Map.Entry<String, String>> placeholders) {
+        private MessageRenderKey {
             locale = Objects.requireNonNull(locale, "locale");
             key = Objects.requireNonNull(key, "key");
         }

--- a/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
+++ b/src/main/java/top/ellan/mahjong/i18n/LocalizedMessages.java
@@ -54,6 +54,40 @@ public final class LocalizedMessages {
         return this.plainTextSerializer.serialize(this.render(locale, key, placeholders));
     }
 
+    /**
+     * Renders a message with placeholders supplied as a plain key/value map.
+     *
+     * <p>This overload is behaviourally identical to the {@link TagResolver} variant
+     * (placeholders are resolved by tag name, so map iteration order is irrelevant). It
+     * exists so hot rendering paths can be measured and cached through a single,
+     * stable placeholder representation.
+     */
+    public Component render(Locale locale, String key, Map<String, String> placeholders) {
+        return this.render(locale, key, resolvers(placeholders));
+    }
+
+    /**
+     * Renders a message to plain text with placeholders supplied as a key/value map.
+     *
+     * <p>See {@link #render(Locale, String, Map)} for the contract shared with the
+     * {@link TagResolver} variant.
+     */
+    public String plain(Locale locale, String key, Map<String, String> placeholders) {
+        return this.plain(locale, key, resolvers(placeholders));
+    }
+
+    /**
+     * Formats a number using the locale-aware integer format used by {@link #number}.
+     */
+    public String formatNumber(Locale locale, String key, Number value) {
+        Locale formatLocale = this.resolveLocales(locale).get(0);
+        NumberFormat format = this.integerFormats.computeIfAbsent(
+            formatLocale,
+            resolvedLocale -> ThreadLocal.withInitial(() -> NumberFormat.getIntegerInstance(resolvedLocale))
+        ).get();
+        return format.format(value);
+    }
+
     public boolean contains(Locale locale, String key) {
         for (Locale candidate : this.resolveLocales(locale)) {
             if (this.bundle(candidate).containsKey(key)) {
@@ -68,12 +102,16 @@ public final class LocalizedMessages {
     }
 
     public TagResolver number(Locale locale, String key, Number value) {
-        Locale formatLocale = this.resolveLocales(locale).get(0);
-        NumberFormat format = this.integerFormats.computeIfAbsent(
-            formatLocale,
-            resolvedLocale -> ThreadLocal.withInitial(() -> NumberFormat.getIntegerInstance(resolvedLocale))
-        ).get();
-        return Placeholder.unparsed(key, format.format(value));
+        return Placeholder.unparsed(key, this.formatNumber(locale, key, value));
+    }
+
+    private static TagResolver[] resolvers(Map<String, String> placeholders) {
+        TagResolver[] resolvers = new TagResolver[placeholders.size()];
+        int index = 0;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            resolvers[index++] = Placeholder.unparsed(entry.getKey(), entry.getValue());
+        }
+        return resolvers;
     }
 
     public Locale normalizeLocale(String rawLocale) {

--- a/src/main/java/top/ellan/mahjong/i18n/MessageService.java
+++ b/src/main/java/top/ellan/mahjong/i18n/MessageService.java
@@ -1,6 +1,7 @@
 package top.ellan.mahjong.i18n;
 
 import java.util.Locale;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandSender;
@@ -27,6 +28,18 @@ public final class MessageService {
 
     public String plain(Locale locale, String key, TagResolver... placeholders) {
         return this.messages.plain(locale, key, placeholders);
+    }
+
+    public Component render(Locale locale, String key, Map<String, String> placeholders) {
+        return this.messages.render(locale, key, placeholders);
+    }
+
+    public String plain(Locale locale, String key, Map<String, String> placeholders) {
+        return this.messages.plain(locale, key, placeholders);
+    }
+
+    public String formatNumber(Locale locale, String key, Number value) {
+        return this.messages.formatNumber(locale, key, value);
     }
 
     public boolean contains(Locale locale, String key) {

--- a/src/main/java/top/ellan/mahjong/i18n/MessageService.java
+++ b/src/main/java/top/ellan/mahjong/i18n/MessageService.java
@@ -61,4 +61,3 @@ public final class MessageService {
         return this.messages.number(locale, key, value);
     }
 }
-

--- a/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
+++ b/src/main/java/top/ellan/mahjong/render/display/DisplayEntities.java
@@ -33,6 +33,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Transformation;
@@ -42,10 +43,26 @@ import org.joml.Vector3f;
 public final class DisplayEntities {
     private static final String ITEM_MODEL_NAMESPACE = "mahjongcraft";
     private static final String MANAGED_ENTITY_KEY = "managed_entity";
+    private static final String TAG_TABLE_ID = "table_id";
+    private static final String TAG_SESSION_ID = "session_id";
+    private static final String TAG_ROLE = "role";
+    private static final String TAG_SLOT = "slot";
+    private static final String TAG_GENERATION = "generation";
     private static final float TILE_SCALE = 1.0F;
     private static final float LABEL_VIEW_RANGE = 48.0F;
     private static final Map<String, ItemStack> TILE_ITEM_CACHE = new ConcurrentHashMap<>();
     private static final Map<Plugin, NamespacedKey> MANAGED_ENTITY_KEYS = new ConcurrentHashMap<>();
+    private static final Map<Plugin, Map<String, NamespacedKey>> MANAGED_ENTITY_TAG_KEYS = new ConcurrentHashMap<>();
+    /**
+     * Ownership metadata written to every entity spawned by this plugin, so that orphaned
+     * display/interaction entities can be attributed to (and safely cleaned up against) a
+     * table even after the in-memory registry is gone. Never contains Bukkit references.
+     */
+    public record ManagedEntityTag(String tableId, String sessionId, String role, String slot, long generation) {
+        public static ManagedEntityTag of(String tableId, String sessionId, String role, String slot, long generation) {
+            return new ManagedEntityTag(tableId, sessionId, role, slot, generation);
+        }
+    }
     /**
      * Last immutable built-in spec applied to a managed entity. Entries use the server entity ID
      * for lock-free lookup but retain the entity only through a queued weak reference; UUID checks
@@ -1598,12 +1615,55 @@ public final class DisplayEntities {
         return entity.getPersistentDataContainer().has(managedEntityKey(plugin), PersistentDataType.BYTE);
     }
 
-    private static void markManagedEntity(Plugin plugin, Entity entity) {
-        entity.getPersistentDataContainer().set(managedEntityKey(plugin), PersistentDataType.BYTE, (byte) 1);
+    public static void markManagedEntity(Plugin plugin, Entity entity) {
+        markManagedEntity(plugin, entity, null);
+    }
+
+    public static void markManagedEntity(Plugin plugin, Entity entity, ManagedEntityTag tag) {
+        if (plugin == null || entity == null) {
+            return;
+        }
+        PersistentDataContainer container = entity.getPersistentDataContainer();
+        container.set(managedEntityKey(plugin), PersistentDataType.BYTE, (byte) 1);
+        if (tag != null) {
+            container.set(managedEntityTagKey(plugin, TAG_TABLE_ID), PersistentDataType.STRING, tag.tableId());
+            container.set(managedEntityTagKey(plugin, TAG_SESSION_ID), PersistentDataType.STRING, tag.sessionId());
+            container.set(managedEntityTagKey(plugin, TAG_ROLE), PersistentDataType.STRING, tag.role());
+            container.set(managedEntityTagKey(plugin, TAG_SLOT), PersistentDataType.STRING, tag.slot());
+            container.set(managedEntityTagKey(plugin, TAG_GENERATION), PersistentDataType.STRING, Long.toString(tag.generation()));
+        }
+    }
+
+    public static ManagedEntityTag readManagedTag(Plugin plugin, Entity entity) {
+        if (plugin == null || entity == null || !isManagedEntity(plugin, entity)) {
+            return null;
+        }
+        PersistentDataContainer container = entity.getPersistentDataContainer();
+        String tableId = container.get(managedEntityTagKey(plugin, TAG_TABLE_ID), PersistentDataType.STRING);
+        String sessionId = container.get(managedEntityTagKey(plugin, TAG_SESSION_ID), PersistentDataType.STRING);
+        String role = container.get(managedEntityTagKey(plugin, TAG_ROLE), PersistentDataType.STRING);
+        String slot = container.get(managedEntityTagKey(plugin, TAG_SLOT), PersistentDataType.STRING);
+        String generation = container.get(managedEntityTagKey(plugin, TAG_GENERATION), PersistentDataType.STRING);
+        if (tableId == null && sessionId == null && role == null && slot == null && generation == null) {
+            return null;
+        }
+        return new ManagedEntityTag(
+            tableId,
+            sessionId,
+            role,
+            slot,
+            generation == null ? 0L : Long.parseLong(generation)
+        );
     }
 
     private static NamespacedKey managedEntityKey(Plugin plugin) {
         return MANAGED_ENTITY_KEYS.computeIfAbsent(plugin, key -> new NamespacedKey(key, MANAGED_ENTITY_KEY));
+    }
+
+    private static NamespacedKey managedEntityTagKey(Plugin plugin, String tag) {
+        return MANAGED_ENTITY_TAG_KEYS
+            .computeIfAbsent(plugin, key -> new ConcurrentHashMap<>())
+            .computeIfAbsent(tag, key -> new NamespacedKey(plugin, MANAGED_ENTITY_KEY + "_" + tag));
     }
 
     private static ItemStack tileItem(DisplayEntityRuntime runtime, MahjongVariant variant, MahjongTile tile, boolean faceDown) {

--- a/src/main/java/top/ellan/mahjong/render/display/ManagedEntityAudit.java
+++ b/src/main/java/top/ellan/mahjong/render/display/ManagedEntityAudit.java
@@ -1,0 +1,72 @@
+package top.ellan.mahjong.render.display;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Scans the live world for entities tagged by {@link DisplayEntities} and reports or cleans
+ * up orphans. An orphan is a managed entity whose {@code table_id} tag does not match any
+ * active table id. Only entities carrying the {@code mahjong:managed_entity} tag are ever
+ * removed by {@link #cleanupOrphans} — generic Interaction/ItemDisplay entities belonging to
+ * other plugins (furniture, NPCs, decorations) are never touched.
+ */
+public final class ManagedEntityAudit {
+
+    public record EntityReport(int total, Map<String, Integer> perTable, List<String> orphans) {
+        public int orphanCount() {
+            return this.orphans.size();
+        }
+    }
+
+    private ManagedEntityAudit() {
+    }
+
+    /** Counts managed entities per table id and collects orphaned entity ids. */
+    public static EntityReport scan(Plugin plugin, Set<String> activeTableIds) {
+        Map<String, Integer> perTable = new LinkedHashMap<>();
+        List<String> orphans = new ArrayList<>();
+        int total = 0;
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                if (!DisplayEntities.isManagedEntity(plugin, entity)) {
+                    continue;
+                }
+                total++;
+                DisplayEntities.ManagedEntityTag tag = DisplayEntities.readManagedTag(plugin, entity);
+                String tableId = tag == null ? null : tag.tableId();
+                if (tableId == null || !activeTableIds.contains(tableId)) {
+                    orphans.add(entity.getUniqueId().toString());
+                } else {
+                    perTable.merge(tableId, 1, Integer::sum);
+                }
+            }
+        }
+        return new EntityReport(total, perTable, orphans);
+    }
+
+    /** Removes managed entities whose table tag no longer matches an active table. Returns removed count. */
+    public static int cleanupOrphans(Plugin plugin, Set<String> activeTableIds) {
+        int removed = 0;
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                if (!DisplayEntities.isManagedEntity(plugin, entity)) {
+                    continue;
+                }
+                DisplayEntities.ManagedEntityTag tag = DisplayEntities.readManagedTag(plugin, entity);
+                String tableId = tag == null ? null : tag.tableId();
+                if (tableId == null || !activeTableIds.contains(tableId)) {
+                    entity.remove();
+                    removed++;
+                }
+            }
+        }
+        return removed;
+    }
+}

--- a/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
+++ b/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
@@ -18,6 +18,7 @@ import top.ellan.mahjong.render.snapshot.TableSeatRenderSnapshot;
 import top.ellan.mahjong.render.snapshot.TableViewerHudSnapshot;
 import top.ellan.mahjong.render.snapshot.TableViewerHudPresentationSnapshot;
 import top.ellan.mahjong.render.snapshot.TableViewerOverlaySnapshot;
+import top.ellan.mahjong.table.action.PlayerActionSnapshotFactory;
 import top.ellan.mahjong.riichi.ReactionResponse;
 import top.ellan.mahjong.riichi.ReactionResponses;
 import top.ellan.mahjong.riichi.RiichiPlayerState;
@@ -104,6 +105,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
     private final TableRenderInspectCoordinator renderInspectCoordinator;
     private final TableLifecycleCoordinator lifecycleCoordinator;
     private final TableViewerSnapshotFactory viewerSnapshotFactory;
+    private final PlayerActionSnapshotFactory actionSnapshotFactory;
     private final TableDiceAnimationCoordinator diceAnimationCoordinator;
     private final TablePlayerFeedbackCoordinator playerFeedbackCoordinator;
     private final TableStateSoundCoordinator stateSoundCoordinator;
@@ -183,6 +185,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         this.renderInspectCoordinator = new TableRenderInspectCoordinator(this.sessionContext);
         this.lifecycleCoordinator = new TableLifecycleCoordinator(this.sessionMutator);
         this.viewerSnapshotFactory = new TableViewerSnapshotFactory(this.sessionMutator);
+        this.actionSnapshotFactory = new PlayerActionSnapshotFactory(this.sessionMutator);
         this.diceAnimationCoordinator = new TableDiceAnimationCoordinator(this.sessionContext);
         this.playerFeedbackCoordinator = new TablePlayerFeedbackCoordinator(this.sessionMutator);
         this.stateSoundCoordinator = new TableStateSoundCoordinator(this.sessionContext);
@@ -200,6 +203,15 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
 
     public TableRuntimeServices plugin() {
         return this.plugin;
+    }
+
+    /**
+     * Shared, stateless action-snapshot factory for this session. Bot strategies
+     * and render paths capture action snapshots every tick, so the factory is
+     * created once per session instead of per capture.
+     */
+    public PlayerActionSnapshotFactory actionSnapshotFactory() {
+        return this.actionSnapshotFactory;
     }
 
     @Override
@@ -1719,7 +1731,11 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
             return this.plugin.messages().plain(locale, "common.unknown");
         }
         int suffix = this.participants.seatIndexOf(playerId) + 1;
-        return this.plugin.messages().plain(locale, "table.bot_name", this.plugin.messages().number(locale, "index", Math.max(1, suffix)));
+        return this.plugin.messages().plain(
+            locale,
+            "table.bot_name",
+            Map.of("index", this.plugin.messages().formatNumber(locale, "index", Math.max(1, suffix)))
+        );
     }
 
     public String tileLabelForDisplay(Locale locale, String tileName) {

--- a/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
+++ b/src/main/java/top/ellan/mahjong/table/core/MahjongTableSession.java
@@ -77,6 +77,14 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
     private final boolean persistentRoom;
     private final boolean botMatchRoom;
     private final TableParticipantRegistry participants = new TableParticipantRegistry();
+    /**
+     * Cache of fully rendered bot display names, keyed by locale tag + '|' + bot player id.
+     * Bot names are deterministic per (locale, seat index) and only change on participant
+     * mutations, so the expensive placeholder-driven i18n render is performed once per key
+     * instead of once per render-snapshot capture (the capture path calls displayName for
+     * every seated player on every tick).
+     */
+    private final Map<String, String> botDisplayNameCache = new HashMap<>();
     private final TableRenderer renderer = new TableRenderer();
     private final TableRenderSnapshotFactory renderSnapshotFactory = new TableRenderSnapshotFactory();
     private final TableRegionFingerprintService regionFingerprintService = new TableRegionFingerprintService();
@@ -328,6 +336,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         this.assignOwnerIfAbsent(playerId);
         this.playerFeedbackCoordinator.clearPlayerState(botId);
         this.handSelectionCoordinator.clearPlayer(botId);
+        this.invalidateBotDisplayNameCache(botId);
         return true;
     }
 
@@ -341,6 +350,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         }
         this.playerFeedbackCoordinator.clearPlayerState(playerId);
         this.handSelectionCoordinator.clearPlayer(playerId);
+        this.invalidateBotDisplayNameCache(playerId);
         this.render();
         return true;
     }
@@ -356,6 +366,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
         boolean removed = this.participants.removePlayer(playerId);
         this.unattendedPlayers.remove(playerId);
         if (removed) {
+            this.invalidateBotDisplayNameCache(playerId);
             DisplayInteractionRayRegistry.clearViewer(playerId, this.id);
         }
         if (removed && Objects.equals(this.ownerId, playerId)) {
@@ -653,6 +664,7 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
 
     public void clearBotNamesForLifecycle() {
         this.participants.clearBotNames();
+        this.botDisplayNameCache.clear();
     }
 
     public void clearSeatAssignmentsForLifecycle() {
@@ -1726,16 +1738,33 @@ public final class MahjongTableSession implements TableSessionMutator, TableMemb
     }
 
     private String botDisplayName(UUID playerId, Locale locale) {
-        String raw = this.participants.botDisplayNameSource(playerId);
-        if (raw == null) {
-            return this.plugin.messages().plain(locale, "common.unknown");
+        String cacheKey = locale.toLanguageTag() + '|' + playerId;
+        String cached = this.botDisplayNameCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
         }
-        int suffix = this.participants.seatIndexOf(playerId) + 1;
-        return this.plugin.messages().plain(
-            locale,
-            "table.bot_name",
-            Map.of("index", this.plugin.messages().formatNumber(locale, "index", Math.max(1, suffix)))
-        );
+        String raw = this.participants.botDisplayNameSource(playerId);
+        String rendered;
+        if (raw == null) {
+            rendered = this.plugin.messages().plain(locale, "common.unknown");
+        } else {
+            int suffix = this.participants.seatIndexOf(playerId) + 1;
+            rendered = this.plugin.messages().plain(
+                locale,
+                "table.bot_name",
+                Map.of("index", this.plugin.messages().formatNumber(locale, "index", Math.max(1, suffix)))
+            );
+        }
+        this.botDisplayNameCache.put(cacheKey, rendered);
+        return rendered;
+    }
+
+    private void invalidateBotDisplayNameCache(UUID playerId) {
+        if (playerId == null) {
+            this.botDisplayNameCache.clear();
+            return;
+        }
+        this.botDisplayNameCache.entrySet().removeIf(entry -> entry.getKey().endsWith('|' + playerId.toString()));
     }
 
     public String tileLabelForDisplay(Locale locale, String tileName) {

--- a/src/main/java/top/ellan/mahjong/table/presentation/TablePublicTextFactory.java
+++ b/src/main/java/top/ellan/mahjong/table/presentation/TablePublicTextFactory.java
@@ -5,6 +5,7 @@ import top.ellan.mahjong.model.MahjongVariant;
 import top.ellan.mahjong.model.SeatWind;
 import top.ellan.mahjong.riichi.model.MahjongRule;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 
 public final class TablePublicTextFactory {
@@ -139,7 +140,7 @@ public final class TablePublicTextFactory {
             return this.session.plugin().messages().plain(
                 locale,
                 "table.public.seat_empty",
-                this.session.plugin().messages().tag("seat", this.seatDisplayName(wind, locale))
+                Map.of("seat", this.seatDisplayName(wind, locale))
             );
         }
         String status = this.waitingSeatStatus(locale, playerId);
@@ -150,9 +151,11 @@ public final class TablePublicTextFactory {
         return this.session.plugin().messages().plain(
             locale,
             "table.public.seat_status",
-            this.session.plugin().messages().tag("seat", this.seatDisplayName(wind, locale)),
-            this.session.plugin().messages().number(locale, "points", this.session.points(playerId)),
-            this.session.plugin().messages().tag("status", status.isBlank() ? "" : " | " + status)
+            Map.of(
+                "seat", this.seatDisplayName(wind, locale),
+                "points", this.session.plugin().messages().formatNumber(locale, "points", this.session.points(playerId)),
+                "status", status.isBlank() ? "" : " | " + status
+            )
         );
     }
 
@@ -165,9 +168,11 @@ public final class TablePublicTextFactory {
         return this.session.plugin().messages().plain(
             locale,
             "table.public.center_waiting",
-            this.session.plugin().messages().tag("table_id", this.session.id()),
-            this.session.plugin().messages().tag("summary", this.waitingDisplaySummary(locale)),
-            this.session.plugin().messages().tag("rules", this.ruleDisplaySummary(locale))
+            Map.of(
+                "table_id", this.session.id(),
+                "summary", this.waitingDisplaySummary(locale),
+                "rules", this.ruleDisplaySummary(locale)
+            )
         );
     }
 

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -501,7 +501,12 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
-        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
+        // Layout structure fingerprint: tile coordinates are fully determined by (seat, hand
+        // size, tile index, selected indices), all covered by the content fingerprints, so the
+        // only structural signal needed for the reconcile-vs-respawn decision is the hand size
+        // itself. Using the already-computed handSize keeps the every-apply enqueue cost at
+        // baseline (no fingerprint computation on the short-circuit path).
+        long layoutFingerprint = handSize;
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -530,7 +535,9 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-public", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
-        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.publicHandLayoutFingerprint(snapshot, seat, plan);
+        // See enqueuePrivateHandRegionUpdates: the layout structure fingerprint is the hand
+        // size itself (all other layout inputs are covered by the content fingerprints).
+        long layoutFingerprint = handSize;
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPublicRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -622,7 +629,7 @@ public final class TableRegionDisplayCoordinator {
     private boolean updatePrivateHandRegions(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, ApplyBudget budget) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
-        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
+        long layoutFingerprint = handSize;
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -911,6 +918,14 @@ public final class TableRegionDisplayCoordinator {
         return true;
     }
 
+    /**
+     * Returns whether the hand structure still matches the layout that was last applied to
+     * this region. The layout fingerprint is the hand size itself (tile coordinates are fully
+     * determined by seat, hand size, tile index and selected indices — all covered by the
+     * content fingerprints), so this only distinguishes "same structure, reconcile in place"
+     * from "hand grew/shrunk, respawn". A zero fingerprint means the region has no layout
+     * gate (non-hand regions) and always reconciles when content changed.
+     */
     private boolean layoutMatches(String regionKey, long layoutFingerprint) {
         if (layoutFingerprint == 0L) {
             return true;

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -80,6 +80,7 @@ public final class TableRegionDisplayCoordinator {
     private final int maxEntitySpawnsPerApply;
     private final Map<String, List<Entity>> regionDisplays = new LinkedHashMap<>();
     private final Map<String, Long> regionFingerprints = new HashMap<>();
+    private final Map<String, Long> appliedLayoutFingerprints = new HashMap<>();
     private final Map<String, Set<UUID>> rayInteractionOwners = new HashMap<>();
     private final Set<String> publicJoinRayRegions = new LinkedHashSet<>();
     private final SparrowViewerOverlayCoordinator clientViewerOverlays;
@@ -500,6 +501,7 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -510,6 +512,7 @@ public final class TableRegionDisplayCoordinator {
             this.enqueue(queue, BUCKET_HAND, () -> this.updatePrivateHandTileRegion(
                 regionKey,
                 this.fingerprintService.handPrivateTileFingerprint(seat, plan, index),
+                layoutFingerprint,
                 budget,
                 seat,
                 plan,
@@ -527,6 +530,7 @@ public final class TableRegionDisplayCoordinator {
     ) {
         this.clearRegion(this.seatRegionKey("hand-public", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.publicHandLayoutFingerprint(snapshot, seat, plan);
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPublicRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -537,6 +541,7 @@ public final class TableRegionDisplayCoordinator {
             this.enqueue(queue, BUCKET_HAND, () -> this.updateRegionWithSpecs(
                 regionKey,
                 this.fingerprintService.handPublicTileFingerprint(snapshot, seat, plan, index),
+                layoutFingerprint,
                 budget,
                 () -> this.session.renderer().renderHandPublicTileSpecs(this.session, snapshot, seat, plan, index)
             ));
@@ -617,6 +622,7 @@ public final class TableRegionDisplayCoordinator {
     private boolean updatePrivateHandRegions(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, ApplyBudget budget) {
         this.clearRegion(this.seatRegionKey("hand-private", seat.wind()));
         int handSize = seat.playerId() == null ? 0 : seat.hand().size();
+        long layoutFingerprint = seat.playerId() == null ? 0L : this.fingerprintService.privateHandLayoutFingerprint(seat, plan);
         for (int tileIndex = 0; tileIndex < MAX_HAND_TILE_REGIONS; tileIndex++) {
             String regionKey = this.handPrivateRegionKey(seat.wind(), tileIndex);
             if (tileIndex >= handSize) {
@@ -627,6 +633,7 @@ public final class TableRegionDisplayCoordinator {
             if (!this.updatePrivateHandTileRegion(
                 regionKey,
                 this.fingerprintService.handPrivateTileFingerprint(seat, plan, tileIndex),
+                layoutFingerprint,
                 budget,
                 seat,
                 plan,
@@ -641,6 +648,7 @@ public final class TableRegionDisplayCoordinator {
     private boolean updatePrivateHandTileRegion(
         String regionKey,
         long fingerprint,
+        long layoutFingerprint,
         ApplyBudget budget,
         TableSeatRenderSnapshot seat,
         TableRenderLayout.SeatLayoutPlan plan,
@@ -654,6 +662,7 @@ public final class TableRegionDisplayCoordinator {
         return this.updateRegionWithRayInteractions(
             regionKey,
             fingerprint,
+            layoutFingerprint,
             budget,
             true,
             () -> {
@@ -674,6 +683,17 @@ public final class TableRegionDisplayCoordinator {
         boolean requiresRayInteractions,
         RayRegionRenderer renderer
     ) {
+        return this.updateRegionWithRayInteractions(regionKey, fingerprint, 0L, budget, requiresRayInteractions, renderer);
+    }
+
+    private boolean updateRegionWithRayInteractions(
+        String regionKey,
+        long fingerprint,
+        long layoutFingerprint,
+        ApplyBudget budget,
+        boolean requiresRayInteractions,
+        RayRegionRenderer renderer
+    ) {
         Long previousFingerprint = this.regionFingerprints.get(regionKey);
         List<Entity> currentEntities = this.regionDisplays.get(regionKey);
         if (this.hasInvalidDisplayEntity(currentEntities)) {
@@ -684,7 +704,8 @@ public final class TableRegionDisplayCoordinator {
         if (previousFingerprint != null
             && previousFingerprint == fingerprint
             && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
-            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))) {
+            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))
+            && this.layoutMatches(regionKey, layoutFingerprint)) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
@@ -695,6 +716,7 @@ public final class TableRegionDisplayCoordinator {
         if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
+            this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
             this.replaceRayInteractions(
                 regionKey,
                 renderPlan.rayInteractions(),
@@ -714,6 +736,7 @@ public final class TableRegionDisplayCoordinator {
             this.regionDisplays.put(regionKey, entities);
         }
         this.regionFingerprints.put(regionKey, fingerprint);
+        this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
         this.replaceRayInteractions(
             regionKey,
             renderPlan.rayInteractions(),
@@ -840,6 +863,10 @@ public final class TableRegionDisplayCoordinator {
     }
 
     private boolean updateRegionWithSpecs(String regionKey, long fingerprint, ApplyBudget budget, RegionSpecRenderer renderer) {
+        return this.updateRegionWithSpecs(regionKey, fingerprint, 0L, budget, renderer);
+    }
+
+    private boolean updateRegionWithSpecs(String regionKey, long fingerprint, long layoutFingerprint, ApplyBudget budget, RegionSpecRenderer renderer) {
         Long previousFingerprint = this.regionFingerprints.get(regionKey);
         List<Entity> currentEntities = this.regionDisplays.get(regionKey);
         if (this.hasInvalidDisplayEntity(currentEntities)) {
@@ -847,7 +874,8 @@ public final class TableRegionDisplayCoordinator {
             previousFingerprint = null;
             currentEntities = null;
         }
-        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))) {
+        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
+                && this.layoutMatches(regionKey, layoutFingerprint)) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
@@ -857,6 +885,7 @@ public final class TableRegionDisplayCoordinator {
         if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
+            this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
             return true;
         }
         if (!budget.canConsumeEntitySpawns(specs.size())) {
@@ -870,12 +899,22 @@ public final class TableRegionDisplayCoordinator {
             this.regionDisplays.put(regionKey, entities);
         }
         this.regionFingerprints.put(regionKey, fingerprint);
+        this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
         return true;
+    }
+
+    private boolean layoutMatches(String regionKey, long layoutFingerprint) {
+        if (layoutFingerprint == 0L) {
+            return true;
+        }
+        Long applied = this.appliedLayoutFingerprints.get(regionKey);
+        return applied != null && applied == layoutFingerprint;
     }
 
     private void clearRegion(String regionKey) {
         this.removeRegionDisplays(regionKey);
         this.regionFingerprints.remove(regionKey);
+        this.appliedLayoutFingerprints.remove(regionKey);
     }
 
     private void removeAllDisplays() {

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -701,11 +701,13 @@ public final class TableRegionDisplayCoordinator {
             previousFingerprint = null;
             currentEntities = null;
         }
+        // Private hand content fingerprints are layout-complete (they include hand size,
+        // selected indices and the tile itself), so the short-circuit needs no layout check;
+        // the layout fingerprint only gates the reconcile-vs-respawn decision below.
         if (previousFingerprint != null
             && previousFingerprint == fingerprint
             && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
-            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))
-            && this.layoutMatches(regionKey, layoutFingerprint)) {
+            && (!requiresRayInteractions || this.rayInteractionsCurrent(regionKey))) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
@@ -713,7 +715,9 @@ public final class TableRegionDisplayCoordinator {
         }
         RayRegionRenderPlan renderPlan = renderer.render();
         List<DisplayEntities.EntitySpec> specs = renderPlan.entitySpecs();
-        if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
+        if (currentEntities != null
+            && this.layoutMatches(regionKey, layoutFingerprint)
+            && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
             this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
@@ -874,15 +878,19 @@ public final class TableRegionDisplayCoordinator {
             previousFingerprint = null;
             currentEntities = null;
         }
-        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))
-                && this.layoutMatches(regionKey, layoutFingerprint)) {
+        // Hand content fingerprints are layout-complete (they include hand size, selected
+        // indices and the tile itself), so the short-circuit needs no separate layout check;
+        // the layout fingerprint only gates the reconcile-vs-respawn decision below.
+        if (previousFingerprint != null && previousFingerprint == fingerprint && (currentEntities != null || this.regionFingerprints.containsKey(regionKey))) {
             return true;
         }
         if (!budget.canConsumeRegionUpdate(1)) {
             return false;
         }
         List<DisplayEntities.EntitySpec> specs = renderer.render();
-        if (currentEntities != null && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
+        if (currentEntities != null
+            && this.layoutMatches(regionKey, layoutFingerprint)
+            && DisplayEntities.reconcile(this.session, currentEntities, specs)) {
             budget.consumeRegionUpdate(1);
             this.regionFingerprints.put(regionKey, fingerprint);
             this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionDisplayCoordinator.java
@@ -75,6 +75,7 @@ public final class TableRegionDisplayCoordinator {
     private static final int BUCKET_BACKGROUND = 4;
 
     private final TableSessionContext session;
+    private long spawnGeneration;
     private final TableRegionFingerprintService fingerprintService;
     private final int maxRegionUpdatesPerApply;
     private final int maxEntitySpawnsPerApply;
@@ -745,6 +746,7 @@ public final class TableRegionDisplayCoordinator {
         List<Entity> entities = DisplayEntities.spawnAll(this.session, specs);
         if (!entities.isEmpty()) {
             this.regionDisplays.put(regionKey, entities);
+            this.markRegionEntities(regionKey, entities);
         }
         this.regionFingerprints.put(regionKey, fingerprint);
         this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
@@ -912,6 +914,7 @@ public final class TableRegionDisplayCoordinator {
         List<Entity> entities = DisplayEntities.spawnAll(this.session, specs);
         if (!entities.isEmpty()) {
             this.regionDisplays.put(regionKey, entities);
+            this.markRegionEntities(regionKey, entities);
         }
         this.regionFingerprints.put(regionKey, fingerprint);
         this.appliedLayoutFingerprints.put(regionKey, layoutFingerprint);
@@ -932,6 +935,33 @@ public final class TableRegionDisplayCoordinator {
         }
         Long applied = this.appliedLayoutFingerprints.get(regionKey);
         return applied != null && applied == layoutFingerprint;
+    }
+
+    /**
+     * Writes ownership metadata (table id, session id, role, slot, generation) into the
+     * persistent data container of every freshly spawned entity so orphans can be attributed
+     * to a table and cleaned up even after the in-memory registry is gone. The role/slot are
+     * derived from the region key (e.g. {@code hand-private:EAST:3} → role {@code hand-private},
+     * slot {@code EAST:3}); generation is a per-coordinator monotonically increasing spawn
+     * counter that lets an audit distinguish a newer respawn from an older one.
+     */
+    private void markRegionEntities(String regionKey, List<Entity> entities) {
+        String tableId = this.session.id();
+        long generation = ++this.spawnGeneration;
+        String role = regionKey;
+        String slot = "";
+        int firstColon = regionKey.indexOf(':');
+        if (firstColon >= 0) {
+            role = regionKey.substring(0, firstColon);
+            slot = regionKey.substring(firstColon + 1);
+        }
+        for (Entity entity : entities) {
+            DisplayEntities.markManagedEntity(
+                this.session.bukkitPlugin(),
+                entity,
+                DisplayEntities.ManagedEntityTag.of(tableId, tableId, role, slot, generation)
+            );
+        }
     }
 
     private void clearRegion(String regionKey) {

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -57,7 +57,14 @@ public final class TableRegionFingerprintService {
             .field("hand-public-tile")
             .field(seat.wind().name())
             .field(seat.playerId())
-            .field(tileIndex)
+            // tileIndex and hand size are packed into a single injective field: hand size
+            // participates in the layout fingerprint, so it must also be part of the content
+            // fingerprint, otherwise a hand that grows/shrinks re-arranges every tile while
+            // the per-tile content fingerprints stay identical and the short-circuit would
+            // wrongly skip the layout update. Packing keeps the field count (and therefore
+            // the every-tick fixed cost) identical to the pre-change fingerprint.
+            // Injective because tileIndex < 64 and hand size < 64 in every legal game state.
+            .field(tileIndex * 64 + seat.hand().size())
             .field(snapshot.started())
             .field(seat.online())
             .field(seat.viewerMembershipSignature())
@@ -65,12 +72,6 @@ public final class TableRegionFingerprintService {
             // Public hand entities are an information boundary: their identity must never depend
             // on a concealed tile, including during the deal/start transition.
             .field("unknown")
-            // Hand size participates in the layout fingerprint, so it must also be part of the
-            // content fingerprint: otherwise a hand that grows/shrinks re-arranges every tile
-            // while the per-tile content fingerprints stay identical and the short-circuit
-            // would wrongly skip the layout update. A per-tile arithmetic field is an order of
-            // magnitude cheaper than a per-region layout lookup on the short-circuit path.
-            .field(seat.hand().size())
             .value();
     }
 

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -256,48 +256,6 @@ public final class TableRegionFingerprintService {
         return region + ":" + wind.name();
     }
 
-    /**
-     * Layout fingerprint for a seat's private hand tiles.
-     *
-     * <p>The per-tile content fingerprint intentionally excludes tile positions so a pure layout
-     * change (hand size growth/shrink re-arranging every tile) does not poison every tile
-     * fingerprint. Tile coordinates are fully determined by (seat, hand size, tile index,
-     * selected indices), all of which are already part of the per-tile content fingerprints,
-     * so the layout fingerprint only needs to carry the hand structure (size): when content
-     * changes but the structure does not, the region can be reconciled in place (teleport)
-     * instead of being respawned.
-     *
-     * <p>This is a deliberately cheap fingerprint (a few FNV fields) because it is computed
-     * once per seat per apply; it never needs to enumerate tile coordinates.
-     */
-    public long privateHandLayoutFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        return fingerprintBuilder(48)
-            .field("hand-private-layout")
-            .field(seat.wind().name())
-            .field(seat.playerId())
-            .field(seat.hand().size())
-            .value();
-    }
-
-    /**
-     * Layout fingerprint for a seat's public hand tiles.
-     *
-     * <p>The per-tile content fingerprint intentionally excludes tile positions, so the layout
-     * fingerprint carries the remaining structural signal (hand size plus the seat identity,
-     * which is already covered by the content fingerprints); the coordinator consults it on
-     * the update path to decide reconcile-vs-respawn. It is cheap to compute (a few FNV
-     * fields, once per seat per apply).
-     */
-    public long publicHandLayoutFingerprint(TableRenderSnapshot snapshot, TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        return fingerprintBuilder(48)
-            .field("hand-public-layout")
-            .field(seat.wind().name())
-            .field(seat.playerId())
-            .field(snapshot.started())
-            .field(seat.hand().size())
-            .value();
-    }
-
     private static FingerprintBuilder fingerprintBuilder(int capacity) {
         return new FingerprintBuilder();
     }

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -35,7 +35,6 @@ public final class TableRegionFingerprintService {
     public long handPrivateTileFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan, int tileIndex) {
         TableRenderLayout.Point point = plan.privateHandPoints().get(tileIndex);
         return fingerprintBuilder(160)
-            .field("hand-private-tile")
             .field(seat.wind().name())
             .field(seat.playerId())
             .field(tileIndex)
@@ -54,7 +53,6 @@ public final class TableRegionFingerprintService {
     ) {
         TableRenderLayout.Point point = plan.publicHandPoints().get(tileIndex);
         return fingerprintBuilder(160)
-            .field("hand-public-tile")
             .field(seat.wind().name())
             .field(seat.playerId())
             // tileIndex and hand size are packed into a single injective field: hand size

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -64,7 +64,7 @@ public final class TableRegionFingerprintService {
             // wrongly skip the layout update. Packing keeps the field count (and therefore
             // the every-tick fixed cost) identical to the pre-change fingerprint.
             // Injective because tileIndex < 64 and hand size < 64 in every legal game state.
-            .field(tileIndex * 64 + seat.hand().size())
+            .field((tileIndex << 6) | seat.hand().size())
             .field(snapshot.started())
             .field(seat.online())
             .field(seat.viewerMembershipSignature())

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -65,6 +65,12 @@ public final class TableRegionFingerprintService {
             // Public hand entities are an information boundary: their identity must never depend
             // on a concealed tile, including during the deal/start transition.
             .field("unknown")
+            // Hand size participates in the layout fingerprint, so it must also be part of the
+            // content fingerprint: otherwise a hand that grows/shrinks re-arranges every tile
+            // while the per-tile content fingerprints stay identical and the short-circuit
+            // would wrongly skip the layout update. A per-tile arithmetic field is an order of
+            // magnitude cheaper than a per-region layout lookup on the short-circuit path.
+            .field(seat.hand().size())
             .value();
     }
 
@@ -250,50 +256,45 @@ public final class TableRegionFingerprintService {
     }
 
     /**
-     * Layout fingerprint for a seat's private hand tiles. The per-tile content fingerprint
-     * intentionally excludes tile positions so a pure layout change (hand size growth/shrink
-     * re-arranging every tile) does not poison every tile fingerprint; the layout fingerprint
-     * is tracked separately so layout-only changes route through reconcile (teleport) instead
-     * of full region respawn.
+     * Layout fingerprint for a seat's private hand tiles.
+     *
+     * <p>The per-tile content fingerprint intentionally excludes tile positions so a pure layout
+     * change (hand size growth/shrink re-arranging every tile) does not poison every tile
+     * fingerprint. Tile coordinates are fully determined by (seat, hand size, tile index,
+     * selected indices), all of which are already part of the per-tile content fingerprints,
+     * so the layout fingerprint only needs to carry the hand structure (size): when content
+     * changes but the structure does not, the region can be reconciled in place (teleport)
+     * instead of being respawned.
+     *
+     * <p>This is a deliberately cheap fingerprint (a few FNV fields) because it is computed
+     * once per seat per apply; it never needs to enumerate tile coordinates.
      */
     public long privateHandLayoutFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        FingerprintBuilder builder = fingerprintBuilder(320)
+        return fingerprintBuilder(48)
             .field("hand-private-layout")
             .field(seat.wind().name())
             .field(seat.playerId())
-            .field(seat.hand().size());
-        List<TableRenderLayout.Point> points = plan.privateHandPoints();
-        for (int i = 0; i < points.size(); i++) {
-            TableRenderLayout.Point point = points.get(i);
-            builder.field(i)
-                .field(Double.doubleToLongBits(point.x()))
-                .field(Double.doubleToLongBits(point.y()))
-                .field(Double.doubleToLongBits(point.z()))
-                .field(seat.selectedHandTileIndices().contains(i));
-        }
-        return builder.value();
+            .field(seat.hand().size())
+            .value();
     }
 
     /**
-     * Layout fingerprint for a seat's public hand tiles. See privateHandLayoutFingerprint
-     * for the rationale.
+     * Layout fingerprint for a seat's public hand tiles.
+     *
+     * <p>The per-tile content fingerprint intentionally excludes tile positions, so the layout
+     * fingerprint carries the remaining structural signal (hand size plus the seat identity,
+     * which is already covered by the content fingerprints); the coordinator consults it on
+     * the update path to decide reconcile-vs-respawn. It is cheap to compute (a few FNV
+     * fields, once per seat per apply).
      */
     public long publicHandLayoutFingerprint(TableRenderSnapshot snapshot, TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
-        FingerprintBuilder builder = fingerprintBuilder(320)
+        return fingerprintBuilder(48)
             .field("hand-public-layout")
             .field(seat.wind().name())
             .field(seat.playerId())
             .field(snapshot.started())
-            .field(seat.hand().size());
-        List<TableRenderLayout.Point> points = plan.publicHandPoints();
-        for (int i = 0; i < points.size(); i++) {
-            TableRenderLayout.Point point = points.get(i);
-            builder.field(i)
-                .field(Double.doubleToLongBits(point.x()))
-                .field(Double.doubleToLongBits(point.y()))
-                .field(Double.doubleToLongBits(point.z()));
-        }
-        return builder.value();
+            .field(seat.hand().size())
+            .value();
     }
 
     private static FingerprintBuilder fingerprintBuilder(int capacity) {

--- a/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
+++ b/src/main/java/top/ellan/mahjong/table/render/TableRegionFingerprintService.java
@@ -6,6 +6,7 @@ import top.ellan.mahjong.render.layout.TableRenderLayout;
 import top.ellan.mahjong.render.snapshot.TableRenderSnapshot;
 import top.ellan.mahjong.render.snapshot.TableSeatRenderSnapshot;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,9 +42,6 @@ public final class TableRegionFingerprintService {
             .field(seat.online())
             .field(seat.hand().size())
             .field(seat.selectedHandTileIndices().contains(tileIndex))
-            .field(Double.doubleToLongBits(point.x()))
-            .field(Double.doubleToLongBits(point.y()))
-            .field(Double.doubleToLongBits(point.z()))
             .field(seat.hand().get(tileIndex).name())
             .value();
     }
@@ -64,9 +62,6 @@ public final class TableRegionFingerprintService {
             .field(seat.online())
             .field(seat.viewerMembershipSignature())
             .field(seat.stickLayoutCount())
-            .field(Double.doubleToLongBits(point.x()))
-            .field(Double.doubleToLongBits(point.y()))
-            .field(Double.doubleToLongBits(point.z()))
             // Public hand entities are an information boundary: their identity must never depend
             // on a concealed tile, including during the deal/start transition.
             .field("unknown")
@@ -252,6 +247,53 @@ public final class TableRegionFingerprintService {
 
     private String seatRegionKey(String region, SeatWind wind) {
         return region + ":" + wind.name();
+    }
+
+    /**
+     * Layout fingerprint for a seat's private hand tiles. The per-tile content fingerprint
+     * intentionally excludes tile positions so a pure layout change (hand size growth/shrink
+     * re-arranging every tile) does not poison every tile fingerprint; the layout fingerprint
+     * is tracked separately so layout-only changes route through reconcile (teleport) instead
+     * of full region respawn.
+     */
+    public long privateHandLayoutFingerprint(TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
+        FingerprintBuilder builder = fingerprintBuilder(320)
+            .field("hand-private-layout")
+            .field(seat.wind().name())
+            .field(seat.playerId())
+            .field(seat.hand().size());
+        List<TableRenderLayout.Point> points = plan.privateHandPoints();
+        for (int i = 0; i < points.size(); i++) {
+            TableRenderLayout.Point point = points.get(i);
+            builder.field(i)
+                .field(Double.doubleToLongBits(point.x()))
+                .field(Double.doubleToLongBits(point.y()))
+                .field(Double.doubleToLongBits(point.z()))
+                .field(seat.selectedHandTileIndices().contains(i));
+        }
+        return builder.value();
+    }
+
+    /**
+     * Layout fingerprint for a seat's public hand tiles. See privateHandLayoutFingerprint
+     * for the rationale.
+     */
+    public long publicHandLayoutFingerprint(TableRenderSnapshot snapshot, TableSeatRenderSnapshot seat, TableRenderLayout.SeatLayoutPlan plan) {
+        FingerprintBuilder builder = fingerprintBuilder(320)
+            .field("hand-public-layout")
+            .field(seat.wind().name())
+            .field(seat.playerId())
+            .field(snapshot.started())
+            .field(seat.hand().size());
+        List<TableRenderLayout.Point> points = plan.publicHandPoints();
+        for (int i = 0; i < points.size(); i++) {
+            TableRenderLayout.Point point = points.get(i);
+            builder.field(i)
+                .field(Double.doubleToLongBits(point.x()))
+                .field(Double.doubleToLongBits(point.y()))
+                .field(Double.doubleToLongBits(point.z()));
+        }
+        return builder.value();
     }
 
     private static FingerprintBuilder fingerprintBuilder(int capacity) {

--- a/src/main/java/top/ellan/mahjong/table/runtime/GbBotStrategy.java
+++ b/src/main/java/top/ellan/mahjong/table/runtime/GbBotStrategy.java
@@ -1,5 +1,6 @@
 package top.ellan.mahjong.table.runtime;
 
+import top.ellan.mahjong.table.action.PlayerActionEntry;
 import top.ellan.mahjong.table.action.PlayerActionId;
 import top.ellan.mahjong.table.action.PlayerActionPhase;
 import top.ellan.mahjong.table.action.PlayerActionSnapshot;
@@ -17,7 +18,7 @@ final class GbBotStrategy implements BotStrategy {
         if (!session.isStarted()) {
             return;
         }
-        PlayerActionSnapshotFactory actionSnapshots = new PlayerActionSnapshotFactory(session);
+        PlayerActionSnapshotFactory actionSnapshots = session.actionSnapshotFactory();
         for (UUID playerId : session.players()) {
             if (!session.isBot(playerId) || actionSnapshots.capture(playerId).phase() != PlayerActionPhase.REACTION) {
                 continue;
@@ -68,7 +69,7 @@ final class GbBotStrategy implements BotStrategy {
     }
 
     private void handleGbReaction(MahjongTableSession session, UUID playerId) {
-        PlayerActionSnapshot snapshot = new PlayerActionSnapshotFactory(session).capture(playerId);
+        PlayerActionSnapshot snapshot = session.actionSnapshotFactory().capture(playerId);
         if (snapshot.phase() != PlayerActionPhase.REACTION) {
             return;
         }
@@ -79,7 +80,7 @@ final class GbBotStrategy implements BotStrategy {
         if (!session.isStarted() || session.hasPendingReaction() || !Objects.equals(session.playerAt(session.currentSeat()), playerId)) {
             return;
         }
-        PlayerActionSnapshot snapshot = new PlayerActionSnapshotFactory(session).capture(playerId);
+        PlayerActionSnapshot snapshot = session.actionSnapshotFactory().capture(playerId);
         if (snapshot.phase() != PlayerActionPhase.TURN) {
             return;
         }
@@ -128,7 +129,12 @@ final class GbBotStrategy implements BotStrategy {
     }
 
     private boolean hasAction(PlayerActionSnapshot snapshot, PlayerActionId actionId) {
-        return snapshot.actions().stream().anyMatch(action -> action.actionId() == actionId);
+        for (PlayerActionEntry action : snapshot.actions()) {
+            if (action.actionId() == actionId) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void scheduleGbTurnRetry(MahjongTableSession session, UUID playerId, int retryAttempts, String reason) {

--- a/src/main/java/top/ellan/mahjong/table/runtime/SichuanBotStrategy.java
+++ b/src/main/java/top/ellan/mahjong/table/runtime/SichuanBotStrategy.java
@@ -43,7 +43,7 @@ final class SichuanBotStrategy implements BotStrategy {
         if (!session.isStarted()) {
             return;
         }
-        PlayerActionSnapshotFactory actionSnapshotFactory = new PlayerActionSnapshotFactory(session);
+        PlayerActionSnapshotFactory actionSnapshotFactory = session.actionSnapshotFactory();
         for (UUID playerId : session.players()) {
             if (!session.isBot(playerId)) {
                 continue;

--- a/src/perfTest/java/top/ellan/mahjong/perf/LocalizedMessagesBenchmark.java
+++ b/src/perfTest/java/top/ellan/mahjong/perf/LocalizedMessagesBenchmark.java
@@ -1,0 +1,88 @@
+package top.ellan.mahjong.perf;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.text.Component;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import top.ellan.mahjong.i18n.LocalizedMessages;
+
+/**
+ * Exercises the parametrised message rendering paths hit by every render flush.
+ *
+ * <p>Each method mirrors a hot Spark-sampled call site: bot display names
+ * ({@code table.bot_name}), per-seat status lines ({@code table.public.seat_status}),
+ * empty-seat placeholders ({@code table.public.seat_empty}) and the table centre line
+ * ({@code table.public.center_waiting}). Placeholders flow through the {@link Map}-based
+ * overload so both implementations (baseline delegation and cached) share one contract.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class LocalizedMessagesBenchmark {
+    private static final String[] SEATS = {"East", "South", "West", "North"};
+    private static final String[] STATUSES = {"", "Riichi", "", "Ready"};
+
+    private final LocalizedMessages messages = new LocalizedMessages();
+    private final Locale locale = LocalizedMessages.DEFAULT_LOCALE;
+    private final String[] points = {
+        this.messages.formatNumber(this.locale, "points", 25_000),
+        this.messages.formatNumber(this.locale, "points", 18_500),
+        this.messages.formatNumber(this.locale, "points", 36_200),
+        this.messages.formatNumber(this.locale, "points", 5_300)
+    };
+
+    @Benchmark
+    public String plainBotName() {
+        return this.messages.plain(this.locale, "table.bot_name", Map.of("index", "1"))
+            + this.messages.plain(this.locale, "table.bot_name", Map.of("index", "2"))
+            + this.messages.plain(this.locale, "table.bot_name", Map.of("index", "3"))
+            + this.messages.plain(this.locale, "table.bot_name", Map.of("index", "4"));
+    }
+
+    @Benchmark
+    public String plainSeatStatus() {
+        String result = "";
+        for (int index = 0; index < 4; index++) {
+            result += this.messages.plain(
+                this.locale,
+                "table.public.seat_status",
+                Map.of("seat", SEATS[index], "points", this.points[index], "status", STATUSES[index])
+            );
+        }
+        return result;
+    }
+
+    @Benchmark
+    public String plainSeatEmpty() {
+        return this.messages.plain(this.locale, "table.public.seat_empty", Map.of("seat", "South"))
+            + this.messages.plain(this.locale, "table.public.seat_empty", Map.of("seat", "West"));
+    }
+
+    @Benchmark
+    public String plainCenterWaiting() {
+        return this.messages.plain(
+            this.locale,
+            "table.public.center_waiting",
+            Map.of("table_id", "table-7", "summary", "Waiting for South")
+        );
+    }
+
+    @Benchmark
+    public Component renderSeatStatus() {
+        Component result = Component.empty();
+        for (int index = 0; index < 4; index++) {
+            result = result.append(this.messages.render(
+                this.locale,
+                "table.public.seat_status",
+                Map.of("seat", SEATS[index], "points", this.points[index], "status", STATUSES[index])
+            ));
+        }
+        return result;
+    }
+}

--- a/src/test/kotlin/top/ellan/mahjong/table/runtime/BotActionSchedulerTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/runtime/BotActionSchedulerTest.kt
@@ -16,6 +16,7 @@ import top.ellan.mahjong.model.MahjongVariant
 import top.ellan.mahjong.model.SeatWind
 import top.ellan.mahjong.runtime.PluginTask
 import top.ellan.mahjong.runtime.ServerScheduler
+import top.ellan.mahjong.table.action.PlayerActionSnapshotFactory
 import top.ellan.mahjong.table.core.MahjongTableSession
 import top.ellan.mahjong.table.core.TableRuntimeServices
 import java.util.UUID
@@ -33,6 +34,7 @@ class BotActionSchedulerTest {
     @Test
     fun `non riichi variant uses gb style bot scheduling`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -58,6 +60,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot turn falls back to selectable discard index`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -96,6 +99,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot exposes a flower before considering kan or discard`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -131,6 +135,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot turn stops retrying after max attempts`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -188,6 +193,7 @@ class BotActionSchedulerTest {
     @Test
     fun `gb bot turn retries reset on next scheduling cycle`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -252,6 +258,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan variant uses sichuan bot strategy`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -280,6 +287,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot exchange preparation uses short delay and one batched submission`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -328,6 +336,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot dingque preparation uses short delay`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -368,6 +377,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot prioritises discarding from smallest suit when all three suits present`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -419,6 +429,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot delegates to engine when already missing one suit`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -468,6 +479,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot declares tsumo when possible`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -502,6 +514,7 @@ class BotActionSchedulerTest {
     @Test
     fun `sichuan bot reaction uses gb suggested reaction`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)

--- a/src/test/kotlin/top/ellan/mahjong/table/runtime/SichuanBotPreparationSchedulerTest.kt
+++ b/src/test/kotlin/top/ellan/mahjong/table/runtime/SichuanBotPreparationSchedulerTest.kt
@@ -13,6 +13,7 @@ import top.ellan.mahjong.model.MahjongVariant
 import top.ellan.mahjong.model.SeatWind
 import top.ellan.mahjong.runtime.PluginTask
 import top.ellan.mahjong.runtime.ServerScheduler
+import top.ellan.mahjong.table.action.PlayerActionSnapshotFactory
 import top.ellan.mahjong.table.core.MahjongTableSession
 import top.ellan.mahjong.table.core.TableRuntimeServices
 import java.util.UUID
@@ -22,6 +23,7 @@ class SichuanBotPreparationSchedulerTest {
     @Test
     fun `dealer bot waits without retries while human dingque is pending`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val center = mock(Location::class.java)
@@ -62,6 +64,7 @@ class SichuanBotPreparationSchedulerTest {
     @Test
     fun `preparation still schedules pending bot after pending human`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)
@@ -91,6 +94,7 @@ class SichuanBotPreparationSchedulerTest {
     @Test
     fun `stale turn task exits during preparation without retry`() {
         val session = mock(MahjongTableSession::class.java)
+        `when`(session.actionSnapshotFactory()).thenReturn(PlayerActionSnapshotFactory(session))
         val plugin = mock(TableRuntimeServices::class.java)
         val scheduler = mock(ServerScheduler::class.java)
         val task = mock(PluginTask::class.java)


### PR DESCRIPTION
## Summary
- **PDC 归属标记**：`DisplayEntities` 新增 5 个 PDC tag（table_id/session_id/role/slot/generation），`TableRegionDisplayCoordinator` 两处 respawn 路径（hand-private / hand-public）对每个新生成的实体写归属，generation 为协调器内单调递增代际计数
- **孤儿扫描**：新增 `ManagedEntityAudit`，只统计/清理**确认无归属**（无 table_id 或归属 table 不存在）的受管实体；`CleanupSubcommand` 提供 `/mahjong cleanup` 清理命令，`DebugSubcommand` 新增 entities 分支列出全部受管实体（位置/类型/归属/世界）
- **启动扫描**：插件 onEnable 尾部 runGlobal 延迟任务执行一次孤儿扫描（仅报告，不自动删）
- **安全边界**：绝不全局删除 Interaction/ItemDisplay，只清理 PDC 标记且归属失效的实体

## Why
线上卡顿根因：JVM 堆顶满 → 频繁老年代 GC（5.33GB 存活对象）。heap dump 诊断前需要实体级归属信息，现有 `mahjong:managed` 标记无法区分归属/代际，无法判断泄漏实体属于哪张桌、哪一轮生成。

## Test plan
- [x] `./gradlew compileJava compileTestJava -PmahjongJavaToolchain=25 -PmahjongJavaTarget=21`
- [x] `./gradlew spotlessJavaCheck`
- [ ] 服务器：`/mahjong debug entities` 列出实体与归属；`/mahjong cleanup` 清理孤儿
- [ ] 重启后观察启动扫描日志（orphan count 应为 0 或仅剩残留）